### PR TITLE
feat: squat rep detection + form analysis with audio cues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "expo": "~54.0.33",
         "expo-camera": "^55.0.11",
         "expo-gl": "^55.0.10",
+        "expo-speech": "~14.0.8",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
@@ -5986,6 +5987,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.16.0"
+      }
+    },
+    "node_modules/expo-speech": {
+      "version": "14.0.8",
+      "resolved": "https://registry.npmjs.org/expo-speech/-/expo-speech-14.0.8.tgz",
+      "integrity": "sha512-UjBFCFv58nutlLw92L7kUS0ZjbOOfaTdiEv/HbjvMrT6BfldoOLLBZbaEcEhDdZK36NY/kass0Kzxk+co6vxSQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-status-bar": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo": "~54.0.33",
     "expo-camera": "^55.0.11",
     "expo-gl": "^55.0.10",
+    "expo-speech": "~14.0.8",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",

--- a/src/components/CameraGuide.tsx
+++ b/src/components/CameraGuide.tsx
@@ -1,0 +1,124 @@
+import React from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  SafeAreaView,
+} from "react-native";
+import type { Exercise } from "../lib/types";
+import { EXERCISE_LABELS } from "../lib/types";
+
+interface CameraGuideProps {
+  exercise: Exercise;
+  onReady: () => void;
+}
+
+const GUIDE_TEXT: Record<Exercise, string> = {
+  squat:
+    "Place your phone 6–8 feet away at hip height, angled to see your side profile. Ensure your full body is visible from head to feet.",
+  deadlift:
+    "Place your phone 6–8 feet away at hip height, angled to see your side profile. Ensure the bar and your full body are visible.",
+  pushup:
+    "Place your phone 3–4 feet away at floor level, angled to see your side profile. Ensure your full body is visible.",
+};
+
+export default function CameraGuide({ exercise, onReady }: CameraGuideProps) {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.content}>
+        <Text style={styles.title}>Camera Setup</Text>
+        <Text style={styles.exercise}>{EXERCISE_LABELS[exercise]}</Text>
+
+        <View style={styles.diagramBox}>
+          <Text style={styles.diagramEmoji}>📱</Text>
+          <View style={styles.arrow} />
+          <Text style={styles.diagramEmoji}>🏋️</Text>
+        </View>
+
+        <Text style={styles.instructions}>{GUIDE_TEXT[exercise]}</Text>
+
+        <View style={styles.tips}>
+          <Text style={styles.tip}>• Good lighting — avoid backlight</Text>
+          <Text style={styles.tip}>• Prop phone against something stable</Text>
+          <Text style={styles.tip}>• Wear fitted clothes for better tracking</Text>
+        </View>
+      </View>
+
+      <TouchableOpacity style={styles.button} onPress={onReady}>
+        <Text style={styles.buttonText}>I'm Ready</Text>
+      </TouchableOpacity>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0a0a0f",
+  },
+  content: {
+    flex: 1,
+    paddingHorizontal: 24,
+    paddingTop: 60,
+  },
+  title: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#ffffff60",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+  },
+  exercise: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: "#ffffff",
+    marginTop: 8,
+    marginBottom: 32,
+  },
+  diagramBox: {
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 20,
+    paddingVertical: 32,
+    backgroundColor: "#1a1a24",
+    borderRadius: 16,
+    marginBottom: 24,
+  },
+  diagramEmoji: {
+    fontSize: 48,
+  },
+  arrow: {
+    width: 40,
+    height: 2,
+    backgroundColor: "#ffffff30",
+  },
+  instructions: {
+    fontSize: 16,
+    color: "#ffffffcc",
+    lineHeight: 24,
+    marginBottom: 24,
+  },
+  tips: {
+    gap: 8,
+  },
+  tip: {
+    fontSize: 14,
+    color: "#ffffff80",
+    lineHeight: 20,
+  },
+  button: {
+    backgroundColor: "#6366f1",
+    marginHorizontal: 24,
+    marginBottom: 40,
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  buttonText: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#ffffff",
+  },
+});

--- a/src/components/CueBanner.tsx
+++ b/src/components/CueBanner.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useRef } from "react";
+import { View, Text, StyleSheet, Animated } from "react-native";
+import * as Speech from "expo-speech";
+import type { FormFlag } from "../lib/types";
+import { FLAG_LABELS } from "../lib/types";
+
+interface CueBannerProps {
+  flag: FormFlag | null;
+  repNumber: number;
+}
+
+export default function CueBanner({ flag, repNumber }: CueBannerProps) {
+  const opacity = useRef(new Animated.Value(0)).current;
+  const lastSpokenRep = useRef(0);
+
+  useEffect(() => {
+    if (repNumber === 0) return;
+
+    // Speak audio cue (max 1 per rep)
+    if (repNumber !== lastSpokenRep.current) {
+      lastSpokenRep.current = repNumber;
+      const text = flag ? FLAG_LABELS[flag] : "Good rep";
+      Speech.speak(text, {
+        language: "en-US",
+        rate: 1.1,
+        pitch: 1.0,
+      });
+    }
+
+    // Flash the visual cue
+    opacity.setValue(1);
+    Animated.timing(opacity, {
+      toValue: 0,
+      duration: 2000,
+      useNativeDriver: true,
+    }).start();
+  }, [repNumber, flag, opacity]);
+
+  if (repNumber === 0) return null;
+
+  const label = flag ? FLAG_LABELS[flag] : "Good rep!";
+  const color = flag ? "#f59e0b" : "#22c55e";
+
+  return (
+    <Animated.View style={[styles.container, { opacity }]}>
+      <View style={[styles.badge, { backgroundColor: color + "20" }]}>
+        <Text style={[styles.repText, { color }]}>Rep {repNumber}</Text>
+        <Text style={[styles.cueText, { color }]}>{label}</Text>
+      </View>
+    </Animated.View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    top: 100,
+    left: 20,
+    right: 20,
+    alignItems: "center",
+  },
+  badge: {
+    borderRadius: 12,
+    paddingHorizontal: 20,
+    paddingVertical: 12,
+  },
+  repText: {
+    fontSize: 14,
+    fontWeight: "700",
+    textAlign: "center",
+  },
+  cueText: {
+    fontSize: 18,
+    fontWeight: "600",
+    textAlign: "center",
+    marginTop: 4,
+  },
+});

--- a/src/components/SafetyBanner.tsx
+++ b/src/components/SafetyBanner.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+import { View, Text, StyleSheet } from "react-native";
+
+export default function SafetyBanner() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>
+        Movement guide — stop if you feel pain
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    bottom: 40,
+    left: 20,
+    right: 20,
+    backgroundColor: "#00000080",
+    borderRadius: 8,
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+  },
+  text: {
+    fontSize: 12,
+    color: "#ffffff99",
+    textAlign: "center",
+  },
+});

--- a/src/hooks/useRepDetector.ts
+++ b/src/hooks/useRepDetector.ts
@@ -1,0 +1,93 @@
+import { useRef, useCallback } from "react";
+import type { Pose } from "@tensorflow-models/pose-detection";
+import type { Exercise, FormFlag } from "../lib/types";
+import {
+  createSquatState,
+  processSquatFrame,
+  type SquatState,
+} from "../lib/formAnalysis/squat";
+
+export interface RepEvent {
+  repNumber: number;
+  flag: FormFlag | null;
+}
+
+interface RepDetectorState {
+  squat: SquatState;
+}
+
+export function useRepDetector(exercise: Exercise) {
+  const stateRef = useRef<RepDetectorState>({
+    squat: createSquatState(),
+  });
+
+  const totalReps = useRef(0);
+  const flagCounts = useRef<Partial<Record<FormFlag, number>>>({});
+
+  const processPose = useCallback(
+    (pose: Pose): RepEvent | null => {
+      if (exercise !== "squat") {
+        // Deadlift and push-up modules will be added in issue #5
+        return null;
+      }
+
+      const result = processSquatFrame(pose, stateRef.current.squat);
+      stateRef.current.squat = result.state;
+
+      if (result.completedRep) {
+        totalReps.current += 1;
+        if (result.flag) {
+          flagCounts.current[result.flag] =
+            (flagCounts.current[result.flag] ?? 0) + 1;
+        }
+        return { repNumber: totalReps.current, flag: result.flag };
+      }
+
+      return null;
+    },
+    [exercise]
+  );
+
+  const getStats = useCallback(() => {
+    return {
+      totalReps: totalReps.current,
+      flagCounts: { ...flagCounts.current },
+      topFlag: getTopFlag(flagCounts.current),
+      score: computeScore(totalReps.current, flagCounts.current),
+    };
+  }, []);
+
+  const reset = useCallback(() => {
+    stateRef.current = { squat: createSquatState() };
+    totalReps.current = 0;
+    flagCounts.current = {};
+  }, []);
+
+  return { processPose, getStats, reset };
+}
+
+function getTopFlag(
+  counts: Partial<Record<FormFlag, number>>
+): FormFlag | null {
+  let top: FormFlag | null = null;
+  let max = 0;
+  for (const [flag, count] of Object.entries(counts)) {
+    if (count! > max) {
+      max = count!;
+      top = flag as FormFlag;
+    }
+  }
+  return top;
+}
+
+function computeScore(
+  totalReps: number,
+  counts: Partial<Record<FormFlag, number>>
+): number {
+  if (totalReps === 0) return 100;
+  const flaggedReps = Object.values(counts).reduce(
+    (sum, c) => sum + (c ?? 0),
+    0
+  );
+  return Math.round(Math.max(0, ((totalReps - flaggedReps) / totalReps) * 100));
+}

--- a/src/lib/formAnalysis/squat.ts
+++ b/src/lib/formAnalysis/squat.ts
@@ -1,0 +1,215 @@
+import type { Keypoint, Pose } from "@tensorflow-models/pose-detection";
+import type { FormFlag } from "../types";
+
+const MIN_CONFIDENCE = 0.3;
+
+// COCO keypoint indices
+const LEFT_HIP = 11;
+const RIGHT_HIP = 12;
+const LEFT_KNEE = 13;
+const RIGHT_KNEE = 14;
+const LEFT_ANKLE = 15;
+const RIGHT_ANKLE = 16;
+const LEFT_SHOULDER = 5;
+const RIGHT_SHOULDER = 6;
+
+type RepPhase = "standing" | "descending" | "bottom" | "ascending";
+
+export interface SquatState {
+  phase: RepPhase;
+  repCount: number;
+  currentRepFlags: FormFlag[];
+  lowestHipY: number;
+}
+
+export function createSquatState(): SquatState {
+  return {
+    phase: "standing",
+    repCount: 0,
+    currentRepFlags: [],
+    lowestHipY: 0,
+  };
+}
+
+function getKeypoint(pose: Pose, index: number): Keypoint | null {
+  const kp = pose.keypoints[index];
+  if (!kp || (kp.score ?? 0) < MIN_CONFIDENCE) return null;
+  return kp;
+}
+
+function midpointY(a: Keypoint, b: Keypoint): number {
+  return (a.y + b.y) / 2;
+}
+
+function midpointX(a: Keypoint, b: Keypoint): number {
+  return (a.x + b.x) / 2;
+}
+
+/**
+ * Compute angle at vertex B in triangle A-B-C (in degrees).
+ */
+function angleDeg(a: Keypoint, b: Keypoint, c: Keypoint): number {
+  const ab = { x: a.x - b.x, y: a.y - b.y };
+  const cb = { x: c.x - b.x, y: c.y - b.y };
+  const dot = ab.x * cb.x + ab.y * cb.y;
+  const magAB = Math.sqrt(ab.x * ab.x + ab.y * ab.y);
+  const magCB = Math.sqrt(cb.x * cb.x + cb.y * cb.y);
+  if (magAB === 0 || magCB === 0) return 180;
+  const cosAngle = Math.max(-1, Math.min(1, dot / (magAB * magCB)));
+  return (Math.acos(cosAngle) * 180) / Math.PI;
+}
+
+/**
+ * Check if hips are below knees (squat depth).
+ * In image space, Y increases downward — so hip below knee means hipY > kneeY.
+ */
+function isAtDepth(hipY: number, kneeY: number): boolean {
+  return hipY > kneeY;
+}
+
+/**
+ * Detect form flags for the current frame.
+ */
+function detectFlags(pose: Pose): FormFlag[] {
+  const flags: FormFlag[] = [];
+
+  const lHip = getKeypoint(pose, LEFT_HIP);
+  const rHip = getKeypoint(pose, RIGHT_HIP);
+  const lKnee = getKeypoint(pose, LEFT_KNEE);
+  const rKnee = getKeypoint(pose, RIGHT_KNEE);
+  const lAnkle = getKeypoint(pose, LEFT_ANKLE);
+  const rAnkle = getKeypoint(pose, RIGHT_ANKLE);
+  const lShoulder = getKeypoint(pose, LEFT_SHOULDER);
+  const rShoulder = getKeypoint(pose, RIGHT_SHOULDER);
+
+  // 1. Knees caving: knee X moving inside ankle X
+  if (lKnee && lAnkle && rKnee && rAnkle) {
+    const lKneeCaving = lKnee.x > lAnkle.x + 5; // left knee drifts right of ankle
+    const rKneeCaving = rKnee.x < rAnkle.x - 5; // right knee drifts left of ankle
+    if (lKneeCaving || rKneeCaving) {
+      flags.push("knees_caving");
+    }
+  }
+
+  // 2. Forward lean: shoulders significantly ahead of hips
+  if (lShoulder && rShoulder && lHip && rHip) {
+    const shoulderX = midpointX(lShoulder, rShoulder);
+    const hipX = midpointX(lHip, rHip);
+    // In side view, forward lean = shoulder X far from hip X
+    // This heuristic works for side-angle camera placement
+    const lean = Math.abs(shoulderX - hipX);
+    if (lean > 30) {
+      flags.push("forward_lean");
+    }
+  }
+
+  return flags;
+}
+
+/**
+ * Process a new pose frame and update squat state.
+ * Returns the flag for the just-completed rep, or null if no rep completed.
+ */
+export function processSquatFrame(
+  pose: Pose,
+  state: SquatState
+): { completedRep: boolean; flag: FormFlag | null; state: SquatState } {
+  const lHip = getKeypoint(pose, LEFT_HIP);
+  const rHip = getKeypoint(pose, RIGHT_HIP);
+  const lKnee = getKeypoint(pose, LEFT_KNEE);
+  const rKnee = getKeypoint(pose, RIGHT_KNEE);
+
+  // Need at least one side of hip + knee visible
+  if ((!lHip && !rHip) || (!lKnee && !rKnee)) {
+    return { completedRep: false, flag: null, state };
+  }
+
+  const hipY = lHip && rHip ? midpointY(lHip, rHip) : (lHip ?? rHip)!.y;
+  const kneeY =
+    lKnee && rKnee ? midpointY(lKnee, rKnee) : (lKnee ?? rKnee)!.y;
+
+  const kneeAngle = (() => {
+    // Compute knee angle (hip-knee-ankle) on whichever side is visible
+    const lAnkle = getKeypoint(pose, LEFT_ANKLE);
+    const rAnkle = getKeypoint(pose, RIGHT_ANKLE);
+    if (lHip && lKnee && lAnkle) return angleDeg(lHip, lKnee, lAnkle);
+    if (rHip && rKnee && rAnkle) return angleDeg(rHip, rKnee, rAnkle);
+    return null;
+  })();
+
+  const newState = { ...state };
+
+  switch (state.phase) {
+    case "standing": {
+      // Detect descent: knee angle closing or hips dropping toward knees
+      if (kneeAngle !== null && kneeAngle < 150) {
+        newState.phase = "descending";
+        newState.currentRepFlags = [];
+        newState.lowestHipY = hipY;
+      }
+      break;
+    }
+
+    case "descending": {
+      // Track lowest point
+      if (hipY > newState.lowestHipY) {
+        newState.lowestHipY = hipY;
+      }
+
+      // Collect flags during descent
+      const frameFlags = detectFlags(pose);
+      for (const f of frameFlags) {
+        if (!newState.currentRepFlags.includes(f)) {
+          newState.currentRepFlags.push(f);
+        }
+      }
+
+      // Check if reached bottom (hips at or below knees)
+      if (isAtDepth(hipY, kneeY) || (kneeAngle !== null && kneeAngle < 90)) {
+        newState.phase = "bottom";
+      }
+      break;
+    }
+
+    case "bottom": {
+      // Collect flags at bottom too
+      const frameFlags = detectFlags(pose);
+      for (const f of frameFlags) {
+        if (!newState.currentRepFlags.includes(f)) {
+          newState.currentRepFlags.push(f);
+        }
+      }
+
+      // Detect ascent: hips rising
+      if (kneeAngle !== null && kneeAngle > 100) {
+        newState.phase = "ascending";
+      }
+      break;
+    }
+
+    case "ascending": {
+      // Rep completes when back to standing (knee angle > 160)
+      if (kneeAngle !== null && kneeAngle > 160) {
+        newState.repCount += 1;
+        newState.phase = "standing";
+
+        // Check depth flag — if hips never went below knees
+        if (!isAtDepth(newState.lowestHipY, kneeY)) {
+          if (!newState.currentRepFlags.includes("depth_too_shallow")) {
+            newState.currentRepFlags.push("depth_too_shallow");
+          }
+        }
+
+        // Pick the most important flag (first detected = most persistent)
+        const flag = newState.currentRepFlags[0] ?? null;
+        newState.currentRepFlags = [];
+        newState.lowestHipY = 0;
+
+        return { completedRep: true, flag, state: newState };
+      }
+      break;
+    }
+  }
+
+  return { completedRep: false, flag: null, state: newState };
+}


### PR DESCRIPTION
## Summary
- **squat.ts**: State machine rep detector (standing→descending→bottom→ascending). Uses knee angle (hip-knee-ankle) + hip/knee Y-position to detect rep phases. Flags: knees_caving, depth_too_shallow, forward_lean
- **useRepDetector.ts**: React hook wrapping the squat analyser. Tracks flag counts per session, computes form score (% clean reps), exposes `processPose`, `getStats`, `reset`
- **CueBanner.tsx**: Animated visual badge + `expo-speech` audio delivery. Max 1 cue per rep. Fades after 2s
- **SafetyBanner.tsx**: Persistent small banner at bottom: "Movement guide — stop if you feel pain"
- **CameraGuide.tsx**: Pre-session screen with phone placement diagram + tips per exercise

Closes #3

## Test plan
- [ ] Squat state machine transitions correctly through phases
- [ ] Rep counted only when full cycle completes (descent → bottom → ascent → standing)
- [ ] Depth flag triggers when hips don't go below knees
- [ ] Audio cue fires once per rep via expo-speech
- [ ] Safety banner always visible during session
- [ ] Camera guide shows before first session

🤖 Generated with [Claude Code](https://claude.com/claude-code)