### PR TITLE
feat: deadlift + push-up form modules (complete MVP exercise set)

### DIFF
--- a/src/hooks/useRepDetector.ts
+++ b/src/hooks/useRepDetector.ts
@@ -6,6 +6,16 @@ import {
   processSquatFrame,
   type SquatState,
 } from "../lib/formAnalysis/squat";
+import {
+  createDeadliftState,
+  processDeadliftFrame,
+  type DeadliftState,
+} from "../lib/formAnalysis/deadlift";
+import {
+  createPushupState,
+  processPushupFrame,
+  type PushupState,
+} from "../lib/formAnalysis/pushup";
 
 export interface RepEvent {
   repNumber: number;
@@ -14,11 +24,15 @@ export interface RepEvent {
 
 interface RepDetectorState {
   squat: SquatState;
+  deadlift: DeadliftState;
+  pushup: PushupState;
 }
 
 export function useRepDetector(exercise: Exercise) {
   const stateRef = useRef<RepDetectorState>({
     squat: createSquatState(),
+    deadlift: createDeadliftState(),
+    pushup: createPushupState(),
   });
 
   const totalReps = useRef(0);
@@ -26,13 +40,28 @@ export function useRepDetector(exercise: Exercise) {
 
   const processPose = useCallback(
     (pose: Pose): RepEvent | null => {
-      if (exercise !== "squat") {
-        // Deadlift and push-up modules will be added in issue #5
-        return null;
-      }
+      let result: { completedRep: boolean; flag: FormFlag | null };
 
-      const result = processSquatFrame(pose, stateRef.current.squat);
-      stateRef.current.squat = result.state;
+      switch (exercise) {
+        case "squat": {
+          const r = processSquatFrame(pose, stateRef.current.squat);
+          stateRef.current.squat = r.state;
+          result = r;
+          break;
+        }
+        case "deadlift": {
+          const r = processDeadliftFrame(pose, stateRef.current.deadlift);
+          stateRef.current.deadlift = r.state;
+          result = r;
+          break;
+        }
+        case "pushup": {
+          const r = processPushupFrame(pose, stateRef.current.pushup);
+          stateRef.current.pushup = r.state;
+          result = r;
+          break;
+        }
+      }
 
       if (result.completedRep) {
         totalReps.current += 1;
@@ -58,7 +87,11 @@ export function useRepDetector(exercise: Exercise) {
   }, []);
 
   const reset = useCallback(() => {
-    stateRef.current = { squat: createSquatState() };
+    stateRef.current = {
+      squat: createSquatState(),
+      deadlift: createDeadliftState(),
+      pushup: createPushupState(),
+    };
     totalReps.current = 0;
     flagCounts.current = {};
   }, []);

--- a/src/lib/formAnalysis/deadlift.ts
+++ b/src/lib/formAnalysis/deadlift.ts
@@ -1,0 +1,176 @@
+import type { Keypoint, Pose } from "@tensorflow-models/pose-detection";
+import type { FormFlag } from "../types";
+
+const MIN_CONFIDENCE = 0.3;
+
+const LEFT_HIP = 11;
+const RIGHT_HIP = 12;
+const LEFT_KNEE = 13;
+const RIGHT_KNEE = 14;
+const LEFT_SHOULDER = 5;
+const RIGHT_SHOULDER = 6;
+const LEFT_ANKLE = 15;
+const RIGHT_ANKLE = 16;
+
+type RepPhase = "standing" | "descending" | "bottom" | "ascending";
+
+export interface DeadliftState {
+  phase: RepPhase;
+  repCount: number;
+  currentRepFlags: FormFlag[];
+}
+
+export function createDeadliftState(): DeadliftState {
+  return { phase: "standing", repCount: 0, currentRepFlags: [] };
+}
+
+function getKp(pose: Pose, idx: number): Keypoint | null {
+  const kp = pose.keypoints[idx];
+  if (!kp || (kp.score ?? 0) < MIN_CONFIDENCE) return null;
+  return kp;
+}
+
+function midY(a: Keypoint, b: Keypoint): number {
+  return (a.y + b.y) / 2;
+}
+
+function angleDeg(a: Keypoint, b: Keypoint, c: Keypoint): number {
+  const ab = { x: a.x - b.x, y: a.y - b.y };
+  const cb = { x: c.x - b.x, y: c.y - b.y };
+  const dot = ab.x * cb.x + ab.y * cb.y;
+  const magAB = Math.sqrt(ab.x * ab.x + ab.y * ab.y);
+  const magCB = Math.sqrt(cb.x * cb.x + cb.y * cb.y);
+  if (magAB === 0 || magCB === 0) return 180;
+  return (Math.acos(Math.max(-1, Math.min(1, dot / (magAB * magCB)))) * 180) / Math.PI;
+}
+
+function detectFlags(pose: Pose): FormFlag[] {
+  const flags: FormFlag[] = [];
+
+  const lShoulder = getKp(pose, LEFT_SHOULDER);
+  const rShoulder = getKp(pose, RIGHT_SHOULDER);
+  const lHip = getKp(pose, LEFT_HIP);
+  const rHip = getKp(pose, RIGHT_HIP);
+  const lKnee = getKp(pose, LEFT_KNEE);
+  const rKnee = getKp(pose, RIGHT_KNEE);
+
+  // Rounded lower back: shoulder Y significantly below hip Y during lift
+  // (in side view, excessive rounding shows shoulders dropping relative to hips)
+  if (lShoulder && rShoulder && lHip && rHip) {
+    const shoulderY = midY(lShoulder, rShoulder);
+    const hipY = midY(lHip, rHip);
+    // Shoulders far below hips (image Y: larger = lower) suggests rounding
+    if (shoulderY - hipY > 25) {
+      flags.push("rounded_lower_back");
+    }
+  }
+
+  // Hips rising early: hip angle opening faster than shoulder angle
+  // Simplified: if hips are rising but shoulders stay low
+  if (lShoulder && rShoulder && lHip && rHip && lKnee && rKnee) {
+    const hipAngle = lHip && lKnee && lShoulder
+      ? angleDeg(lShoulder, lHip, lKnee)
+      : rHip && rKnee && rShoulder
+        ? angleDeg(rShoulder, rHip, rKnee)
+        : null;
+    // Very acute hip angle with knees already extending = hips rising early
+    if (hipAngle !== null && hipAngle < 70) {
+      flags.push("hips_rising_early");
+    }
+  }
+
+  // Bar drift: shoulders ahead of ankles (X distance in side view)
+  const lAnkle = getKp(pose, LEFT_ANKLE);
+  const rAnkle = getKp(pose, RIGHT_ANKLE);
+  if (lShoulder && rShoulder && lAnkle && rAnkle) {
+    const shoulderX = (lShoulder.x + rShoulder.x) / 2;
+    const ankleX = (lAnkle.x + rAnkle.x) / 2;
+    if (Math.abs(shoulderX - ankleX) > 35) {
+      flags.push("bar_drift");
+    }
+  }
+
+  return flags;
+}
+
+export function processDeadliftFrame(
+  pose: Pose,
+  state: DeadliftState
+): { completedRep: boolean; flag: FormFlag | null; state: DeadliftState } {
+  const lHip = getKp(pose, LEFT_HIP);
+  const rHip = getKp(pose, RIGHT_HIP);
+  const lKnee = getKp(pose, LEFT_KNEE);
+  const rKnee = getKp(pose, RIGHT_KNEE);
+  const lShoulder = getKp(pose, LEFT_SHOULDER);
+  const rShoulder = getKp(pose, RIGHT_SHOULDER);
+
+  if ((!lHip && !rHip) || (!lShoulder && !rShoulder)) {
+    return { completedRep: false, flag: null, state };
+  }
+
+  // Hip angle: shoulder-hip-knee
+  const hipAngle = (() => {
+    if (lShoulder && lHip && lKnee) return angleDeg(lShoulder, lHip, lKnee);
+    if (rShoulder && rHip && rKnee) return angleDeg(rShoulder, rHip, rKnee);
+    return null;
+  })();
+
+  const newState = { ...state };
+
+  switch (state.phase) {
+    case "standing": {
+      // Descent: hip angle closing (bending forward)
+      if (hipAngle !== null && hipAngle < 140) {
+        newState.phase = "descending";
+        newState.currentRepFlags = [];
+      }
+      break;
+    }
+
+    case "descending": {
+      const frameFlags = detectFlags(pose);
+      for (const f of frameFlags) {
+        if (!newState.currentRepFlags.includes(f)) {
+          newState.currentRepFlags.push(f);
+        }
+      }
+
+      // Bottom: hip angle very closed (hands near floor)
+      if (hipAngle !== null && hipAngle < 80) {
+        newState.phase = "bottom";
+      }
+      break;
+    }
+
+    case "bottom": {
+      const frameFlags = detectFlags(pose);
+      for (const f of frameFlags) {
+        if (!newState.currentRepFlags.includes(f)) {
+          newState.currentRepFlags.push(f);
+        }
+      }
+
+      // Ascending: hip angle opening
+      if (hipAngle !== null && hipAngle > 100) {
+        newState.phase = "ascending";
+      }
+      break;
+    }
+
+    case "ascending": {
+      // Lockout: hip angle near straight
+      if (hipAngle !== null && hipAngle > 160) {
+        newState.repCount += 1;
+        newState.phase = "standing";
+
+        const flag = newState.currentRepFlags[0] ?? null;
+        newState.currentRepFlags = [];
+
+        return { completedRep: true, flag, state: newState };
+      }
+      break;
+    }
+  }
+
+  return { completedRep: false, flag: null, state: newState };
+}

--- a/src/lib/formAnalysis/pushup.ts
+++ b/src/lib/formAnalysis/pushup.ts
@@ -1,0 +1,182 @@
+import type { Keypoint, Pose } from "@tensorflow-models/pose-detection";
+import type { FormFlag } from "../types";
+
+const MIN_CONFIDENCE = 0.3;
+
+const LEFT_SHOULDER = 5;
+const RIGHT_SHOULDER = 6;
+const LEFT_ELBOW = 7;
+const RIGHT_ELBOW = 8;
+const LEFT_WRIST = 9;
+const RIGHT_WRIST = 10;
+const LEFT_HIP = 11;
+const RIGHT_HIP = 12;
+const LEFT_ANKLE = 15;
+const RIGHT_ANKLE = 16;
+
+type RepPhase = "up" | "descending" | "bottom" | "ascending";
+
+export interface PushupState {
+  phase: RepPhase;
+  repCount: number;
+  currentRepFlags: FormFlag[];
+  lowestShoulderY: number;
+}
+
+export function createPushupState(): PushupState {
+  return { phase: "up", repCount: 0, currentRepFlags: [], lowestShoulderY: 0 };
+}
+
+function getKp(pose: Pose, idx: number): Keypoint | null {
+  const kp = pose.keypoints[idx];
+  if (!kp || (kp.score ?? 0) < MIN_CONFIDENCE) return null;
+  return kp;
+}
+
+function angleDeg(a: Keypoint, b: Keypoint, c: Keypoint): number {
+  const ab = { x: a.x - b.x, y: a.y - b.y };
+  const cb = { x: c.x - b.x, y: c.y - b.y };
+  const dot = ab.x * cb.x + ab.y * cb.y;
+  const magAB = Math.sqrt(ab.x * ab.x + ab.y * ab.y);
+  const magCB = Math.sqrt(cb.x * cb.x + cb.y * cb.y);
+  if (magAB === 0 || magCB === 0) return 180;
+  return (Math.acos(Math.max(-1, Math.min(1, dot / (magAB * magCB)))) * 180) / Math.PI;
+}
+
+function detectFlags(pose: Pose): FormFlag[] {
+  const flags: FormFlag[] = [];
+
+  const lShoulder = getKp(pose, LEFT_SHOULDER);
+  const rShoulder = getKp(pose, RIGHT_SHOULDER);
+  const lHip = getKp(pose, LEFT_HIP);
+  const rHip = getKp(pose, RIGHT_HIP);
+  const lAnkle = getKp(pose, LEFT_ANKLE);
+  const rAnkle = getKp(pose, RIGHT_ANKLE);
+  const lElbow = getKp(pose, LEFT_ELBOW);
+  const rElbow = getKp(pose, RIGHT_ELBOW);
+
+  // Hips sagging: hip Y significantly below shoulder-ankle line
+  if (lShoulder && rShoulder && lHip && rHip && lAnkle && rAnkle) {
+    const shoulderY = (lShoulder.y + rShoulder.y) / 2;
+    const ankleY = (lAnkle.y + rAnkle.y) / 2;
+    const hipY = (lHip.y + rHip.y) / 2;
+    // Expected: hip Y roughly between shoulder and ankle
+    // Sagging: hip Y drops well below the midline
+    const midline = (shoulderY + ankleY) / 2;
+    if (hipY > midline + 15) {
+      flags.push("hips_sagging");
+    }
+  }
+
+  // Elbows flaring: elbow X far outside shoulder X
+  if (lShoulder && lElbow && rShoulder && rElbow) {
+    // From front/side view, flaring = elbows significantly wider than shoulders
+    const shoulderWidth = Math.abs(lShoulder.x - rShoulder.x);
+    const elbowWidth = Math.abs(lElbow.x - rElbow.x);
+    if (elbowWidth > shoulderWidth * 1.4) {
+      flags.push("elbows_flaring");
+    }
+  }
+
+  return flags;
+}
+
+export function processPushupFrame(
+  pose: Pose,
+  state: PushupState
+): { completedRep: boolean; flag: FormFlag | null; state: PushupState } {
+  const lShoulder = getKp(pose, LEFT_SHOULDER);
+  const rShoulder = getKp(pose, RIGHT_SHOULDER);
+  const lElbow = getKp(pose, LEFT_ELBOW);
+  const rElbow = getKp(pose, RIGHT_ELBOW);
+  const lWrist = getKp(pose, LEFT_WRIST);
+  const rWrist = getKp(pose, RIGHT_WRIST);
+
+  if ((!lShoulder && !rShoulder) || (!lElbow && !rElbow)) {
+    return { completedRep: false, flag: null, state };
+  }
+
+  // Elbow angle: shoulder-elbow-wrist
+  const elbowAngle = (() => {
+    if (lShoulder && lElbow && lWrist) return angleDeg(lShoulder, lElbow, lWrist);
+    if (rShoulder && rElbow && rWrist) return angleDeg(rShoulder, rElbow, rWrist);
+    return null;
+  })();
+
+  const shoulderY = lShoulder && rShoulder
+    ? (lShoulder.y + rShoulder.y) / 2
+    : (lShoulder ?? rShoulder)!.y;
+
+  const newState = { ...state };
+
+  switch (state.phase) {
+    case "up": {
+      // Descent: elbow angle closing
+      if (elbowAngle !== null && elbowAngle < 150) {
+        newState.phase = "descending";
+        newState.currentRepFlags = [];
+        newState.lowestShoulderY = shoulderY;
+      }
+      break;
+    }
+
+    case "descending": {
+      if (shoulderY > newState.lowestShoulderY) {
+        newState.lowestShoulderY = shoulderY;
+      }
+
+      const frameFlags = detectFlags(pose);
+      for (const f of frameFlags) {
+        if (!newState.currentRepFlags.includes(f)) {
+          newState.currentRepFlags.push(f);
+        }
+      }
+
+      // Bottom: elbow angle very closed
+      if (elbowAngle !== null && elbowAngle < 90) {
+        newState.phase = "bottom";
+      }
+      break;
+    }
+
+    case "bottom": {
+      const frameFlags = detectFlags(pose);
+      for (const f of frameFlags) {
+        if (!newState.currentRepFlags.includes(f)) {
+          newState.currentRepFlags.push(f);
+        }
+      }
+
+      // Ascending: elbow opening
+      if (elbowAngle !== null && elbowAngle > 110) {
+        newState.phase = "ascending";
+      }
+      break;
+    }
+
+    case "ascending": {
+      // Full extension: elbow angle > 160
+      if (elbowAngle !== null && elbowAngle > 160) {
+        newState.repCount += 1;
+        newState.phase = "up";
+
+        // Check incomplete range — if elbow never went below 90
+        if (newState.lowestShoulderY < shoulderY - 5) {
+          // Shoulder barely dropped — incomplete range
+          if (!newState.currentRepFlags.includes("incomplete_range")) {
+            newState.currentRepFlags.push("incomplete_range");
+          }
+        }
+
+        const flag = newState.currentRepFlags[0] ?? null;
+        newState.currentRepFlags = [];
+        newState.lowestShoulderY = 0;
+
+        return { completedRep: true, flag, state: newState };
+      }
+      break;
+    }
+  }
+
+  return { completedRep: false, flag: null, state: newState };
+}


### PR DESCRIPTION
## Summary
- **deadlift.ts**: Hip-angle based state machine (standing→descending→bottom→ascending). Flags: rounded_lower_back (shoulder-hip Y offset), hips_rising_early (acute hip angle), bar_drift (shoulder-ankle X offset)
- **pushup.ts**: Elbow-angle based state machine (up→descending→bottom→ascending). Flags: hips_sagging (hip below shoulder-ankle midline), elbows_flaring (elbow width > 1.4x shoulder width), incomplete_range (shoulder barely descends)
- **useRepDetector.ts**: Switch statement dispatches to squat/deadlift/pushup analysers. State for all 3 maintained in refs

Closes #5

## Test plan
- [ ] Deadlift reps detected via hip angle (lockout at >160°)
- [ ] Push-up reps detected via elbow angle (extension at >160°)
- [ ] Flags trigger correctly for each exercise
- [ ] useRepDetector switch routes to correct analyser per exercise
- [ ] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)