### PR TITLE
Configure EAS Build for TestFlight distribution

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -1,0 +1,9 @@
+node_modules/
+.git/
+docs/
+**/*.test.ts
+**/*.test.tsx
+**/*.spec.ts
+**/*.spec.tsx
+__tests__/
+.claude/

--- a/app.json
+++ b/app.json
@@ -16,6 +16,7 @@
       "supportsTablet": false,
       "bundleIdentifier": "com.wkliwk.gymformcoach",
       "deploymentTarget": "14.0",
+      "buildNumber": "1",
       "infoPlist": {
         "NSCameraUsageDescription": "Gym Form Coach uses your camera to analyze exercise form in real time. All processing happens on your device — no video is uploaded."
       }

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,34 @@
+{
+  "cli": {
+    "version": ">= 15.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "ios": {
+        "simulator": true
+      }
+    },
+    "preview": {
+      "distribution": "internal",
+      "ios": {
+        "simulator": false
+      }
+    },
+    "production": {
+      "distribution": "store",
+      "autoIncrement": true
+    }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "appleId": "",
+        "ascAppId": "",
+        "appleTeamId": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Create `eas.json` with 3 build profiles: development (simulator), preview (ad-hoc), production (store)
- Add `buildNumber: "1"` to `app.json` ios config
- Add `.easignore` to exclude node_modules, .git, docs, test files from EAS uploads

Closes #14

## Test plan
- [ ] `eas.json` has valid JSON structure
- [ ] `app.json` has `buildNumber` under `ios`
- [ ] `.easignore` excludes expected paths
- [ ] `npx tsc --noEmit` passes
- [ ] Note: actual `eas build` requires Apple Developer credentials (interactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)