### PR TITLE
Fix CueBanner overlap with exercise header on small iPhones

### DIFF
--- a/src/components/CueBanner.tsx
+++ b/src/components/CueBanner.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useRef } from "react";
-import { View, Text, StyleSheet, Animated } from "react-native";
+import { View, Text, StyleSheet, Animated, Platform, Dimensions } from "react-native";
 import * as Speech from "expo-speech";
 import type { FormFlag } from "../lib/types";
 import { FLAG_LABELS } from "../lib/types";
+
+const { height: SCREEN_HEIGHT } = Dimensions.get("window");
+// Position below exercise header (safe area + header + rep counter + gap)
+// Scales proportionally: ~18% from top on standard iPhones, clamps for small screens
+const CUE_TOP = Math.max(140, Math.round(SCREEN_HEIGHT * 0.18));
 
 interface CueBannerProps {
   flag: FormFlag | null;
@@ -54,7 +59,7 @@ export default function CueBanner({ flag, repNumber }: CueBannerProps) {
 const styles = StyleSheet.create({
   container: {
     position: "absolute",
-    top: 100,
+    top: CUE_TOP,
     left: 20,
     right: 20,
     alignItems: "center",


### PR DESCRIPTION
## Summary
- Replace hardcoded `top: 100` in CueBanner with dynamic positioning based on screen height
- Uses 18% of screen height (min 140px) to clear exercise header + rep counter
- Prevents overlap on iPhone SE/Mini while maintaining layout on larger devices

Closes #23

## Test plan
- [ ] CueBanner below exercise header on iPhone SE simulator
- [ ] CueBanner below exercise header on iPhone 15 Pro simulator
- [ ] Fade animation still works
- [ ] `npx tsc --noEmit` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)