### PR TITLE
Update Android adaptive icon background to dark theme

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,7 +25,7 @@
       "package": "com.wkliwk.gymformcoach",
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
-        "backgroundColor": "#ffffff"
+        "backgroundColor": "#0a0a0f"
       },
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false,


### PR DESCRIPTION
## Summary
- Changed `android.adaptiveIcon.backgroundColor` from white (#ffffff) to dark (#0a0a0f) to match the app's dark theme
- The adaptive icon foreground (cyan dumbbell) is designed to work on dark backgrounds
- This improves visual consistency and professionalism on Android launchers

## Platforms Tested
- [x] TypeScript check (`npx tsc --noEmit`)
- [ ] iOS Simulator (config-only change, no iOS impact)
- [ ] Android Emulator (requires EAS build for final verification)

## Acceptance Criteria
- [x] `android.adaptiveIcon.backgroundColor` set to dark color (#0a0a0f)
- [x] Adaptive icon foreground image has correct safe-zone margins
- [x] Icon looks intentional and professional (bright cyan on dark background)
- [x] Splash screen background already matches app theme (#0a0a0f)
- [ ] New EAS build completes successfully (pending QA review)
- [x] `npx tsc --noEmit` passes

## Test Plan
1. Verify the change in app.json by reviewing the diff
2. Run EAS build for Android to verify the APK builds successfully with the new background color
3. Test on an Android device/emulator to verify the adaptive icon displays correctly on various launcher icon shapes (circle, rounded square, squircle, teardrop)
4. Verify the icon looks intentional and matches the app's dark theme

Closes #35