### PR TITLE
feat: add delete session and clear all history (#33)

### DIFF
--- a/src/lib/sessionStorage.ts
+++ b/src/lib/sessionStorage.ts
@@ -27,6 +27,16 @@ export async function addSession(session: SessionRecord): Promise<void> {
   await saveSessions(sessions);
 }
 
+export async function deleteSession(id: string): Promise<void> {
+  const sessions = await loadSessions();
+  const filtered = sessions.filter((s) => s.id !== id);
+  await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(filtered));
+}
+
+export async function clearAllSessions(): Promise<void> {
+  await AsyncStorage.removeItem(STORAGE_KEY);
+}
+
 export function findPreviousSession(
   sessions: SessionRecord[],
   exercise: string,

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -6,11 +6,18 @@ import {
   FlatList,
   SafeAreaView,
   TouchableOpacity,
+  Alert,
+  Pressable,
 } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
 import type { SessionRecord } from "../lib/types";
 import { EXERCISE_LABELS, FLAG_LABELS } from "../lib/types";
-import { loadSessions, findPreviousSession } from "../lib/sessionStorage";
+import {
+  loadSessions,
+  findPreviousSession,
+  deleteSession,
+  clearAllSessions,
+} from "../lib/sessionStorage";
 
 const MAX_DISPLAY = 10;
 
@@ -24,7 +31,13 @@ function formatDate(iso: string): string {
   });
 }
 
-function DeltaBadge({ sessions, session }: { sessions: SessionRecord[]; session: SessionRecord }) {
+function DeltaBadge({
+  sessions,
+  session,
+}: {
+  sessions: SessionRecord[];
+  session: SessionRecord;
+}) {
   const prev = findPreviousSession(sessions, session.exercise, session.id);
   if (!prev) return null;
   const delta = session.reps - prev.reps;
@@ -38,10 +51,7 @@ function DeltaBadge({ sessions, session }: { sessions: SessionRecord[]; session:
       ]}
     >
       <Text
-        style={[
-          styles.deltaText,
-          { color: positive ? "#22c55e" : "#ef4444" },
-        ]}
+        style={[styles.deltaText, { color: positive ? "#22c55e" : "#ef4444" }]}
       >
         {positive ? "+" : ""}
         {delta} reps
@@ -53,11 +63,46 @@ function DeltaBadge({ sessions, session }: { sessions: SessionRecord[]; session:
 export default function HistoryScreen() {
   const [sessions, setSessions] = useState<SessionRecord[]>([]);
 
-  useFocusEffect(
-    useCallback(() => {
-      loadSessions().then((s) => setSessions(s.slice(0, MAX_DISPLAY)));
-    }, [])
+  const refresh = useCallback(() => {
+    loadSessions().then((s) => setSessions(s.slice(0, MAX_DISPLAY)));
+  }, []);
+
+  useFocusEffect(refresh);
+
+  const handleDeleteSession = useCallback(
+    (id: string) => {
+      Alert.alert("Delete Session", "Remove this session from your history?", [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Delete",
+          style: "destructive",
+          onPress: async () => {
+            await deleteSession(id);
+            refresh();
+          },
+        },
+      ]);
+    },
+    [refresh]
   );
+
+  const handleClearAll = useCallback(() => {
+    Alert.alert(
+      "Clear All History",
+      "This will permanently delete all session records. This cannot be undone.",
+      [
+        { text: "Cancel", style: "cancel" },
+        {
+          text: "Clear All",
+          style: "destructive",
+          onPress: async () => {
+            await clearAllSessions();
+            refresh();
+          },
+        },
+      ]
+    );
+  }, [refresh]);
 
   const renderItem = ({ item }: { item: SessionRecord }) => (
     <View style={styles.sessionCard}>
@@ -65,7 +110,20 @@ export default function HistoryScreen() {
         <Text style={styles.exerciseLabel}>
           {EXERCISE_LABELS[item.exercise] ?? item.exercise}
         </Text>
-        <Text style={styles.dateLabel}>{formatDate(item.date)}</Text>
+        <View style={styles.sessionHeaderRight}>
+          <Text style={styles.dateLabel}>{formatDate(item.date)}</Text>
+          <Pressable
+            onPress={() => handleDeleteSession(item.id)}
+            style={({ pressed }) => [
+              styles.deleteButton,
+              pressed && styles.deleteButtonPressed,
+            ]}
+            accessibilityLabel="Delete session"
+            accessibilityRole="button"
+          >
+            <Text style={styles.deleteButtonText}>✕</Text>
+          </Pressable>
+        </View>
       </View>
 
       <View style={styles.sessionStats}>
@@ -85,7 +143,19 @@ export default function HistoryScreen() {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>Session History</Text>
+        <View style={styles.headerTop}>
+          <Text style={styles.title}>Session History</Text>
+          {sessions.length > 0 && (
+            <TouchableOpacity
+              onPress={handleClearAll}
+              style={styles.clearAllButton}
+              accessibilityLabel="Clear all history"
+              accessibilityRole="button"
+            >
+              <Text style={styles.clearAllText}>Clear All</Text>
+            </TouchableOpacity>
+          )}
+        </View>
         <Text style={styles.subtitle}>Last {MAX_DISPLAY} sessions</Text>
       </View>
 
@@ -119,6 +189,11 @@ const styles = StyleSheet.create({
     paddingTop: 20,
     paddingBottom: 12,
   },
+  headerTop: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
   title: {
     fontSize: 28,
     fontWeight: "700",
@@ -128,6 +203,18 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: "#ffffff50",
     marginTop: 4,
+  },
+  clearAllButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: "#ef444460",
+  },
+  clearAllText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ef4444",
   },
   list: {
     paddingHorizontal: 20,
@@ -145,14 +232,36 @@ const styles = StyleSheet.create({
     alignItems: "center",
     marginBottom: 10,
   },
+  sessionHeaderRight: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
   exerciseLabel: {
     fontSize: 17,
     fontWeight: "600",
     color: "#ffffff",
+    flex: 1,
   },
   dateLabel: {
     fontSize: 13,
     color: "#ffffff50",
+  },
+  deleteButton: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    backgroundColor: "#ef444420",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  deleteButtonPressed: {
+    backgroundColor: "#ef444450",
+  },
+  deleteButtonText: {
+    fontSize: 12,
+    color: "#ef4444",
+    fontWeight: "700",
   },
   sessionStats: {
     flexDirection: "row",


### PR DESCRIPTION
## What
Adds the ability to delete individual sessions and clear all history from the History screen.

- `deleteSession(id)` — removes a single session from AsyncStorage by filtering out the matching id
- `clearAllSessions()` — removes the entire sessions key from AsyncStorage
- Each session card now has a circular ✕ icon button that triggers a confirmation Alert before deleting
- A "Clear All" button appears in the header when sessions exist, guarded by a confirmation Alert
- The list refreshes immediately after any deletion (no navigate-away required)
- Empty state shown automatically when all sessions are cleared

## Why
Closes #33

## Platforms Tested
- [ ] iOS Simulator
- [ ] Android Emulator

## Acceptance Criteria
- [x] `deleteSession(id)` removes a single session from AsyncStorage
- [x] `clearAllSessions()` removes all sessions from AsyncStorage
- [x] Individual session cards have a delete action (✕ icon button)
- [x] "Clear All" button visible in History screen header
- [x] Confirmation dialog shown before "Clear All" (prevent accidental deletion)
- [x] After deletion, History list updates immediately (no need to navigate away and back)
- [x] Empty state shown when all sessions are cleared
- [x] `npx tsc --noEmit` passes (no new errors introduced)

## Test Plan
1. Open the app and complete at least one session to populate history
2. Tap the ✕ icon on a session card — confirm dialog appears, tap Delete — card disappears immediately
3. Tap Cancel on the confirm dialog — nothing is deleted
4. Tap "Clear All" in the header — confirm dialog appears, tap Clear All — list clears and empty state shows
5. Tap Cancel on Clear All dialog — nothing is deleted
6. Verify "Clear All" button is not shown when the list is empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)