### PR TITLE
feat: progress tracking, personal bests, score trends

### DIFF
--- a/src/__tests__/progressHelpers.test.ts
+++ b/src/__tests__/progressHelpers.test.ts
@@ -1,0 +1,134 @@
+import type { SessionRecord } from "../lib/types";
+import {
+  getPersonalBests,
+  getWorkoutStreak,
+  getTotalReps,
+  getScoreTrend,
+} from "../lib/sessionStorage";
+
+function makeSession(
+  overrides: Partial<SessionRecord> & { id: string }
+): SessionRecord {
+  return {
+    date: "2026-04-01T10:00:00.000Z",
+    exercise: "squat",
+    reps: 10,
+    topFlag: null,
+    score: 80,
+    ...overrides,
+  };
+}
+
+describe("getPersonalBests", () => {
+  it("returns empty for no sessions", () => {
+    expect(getPersonalBests([])).toEqual({});
+  });
+
+  it("returns best score per exercise", () => {
+    const sessions: SessionRecord[] = [
+      makeSession({ id: "1", exercise: "squat", score: 70, date: "2026-04-01T10:00:00Z" }),
+      makeSession({ id: "2", exercise: "squat", score: 90, date: "2026-04-02T10:00:00Z" }),
+      makeSession({ id: "3", exercise: "deadlift", score: 85, date: "2026-04-01T10:00:00Z" }),
+    ];
+    const bests = getPersonalBests(sessions);
+    expect(bests.squat).toEqual({ score: 90, date: "2026-04-02T10:00:00Z" });
+    expect(bests.deadlift).toEqual({ score: 85, date: "2026-04-01T10:00:00Z" });
+    expect(bests.pushup).toBeUndefined();
+  });
+});
+
+describe("getWorkoutStreak", () => {
+  it("returns zero for no sessions", () => {
+    expect(getWorkoutStreak([])).toEqual({ current: 0, best: 0 });
+  });
+
+  it("counts consecutive days", () => {
+    const today = new Date();
+    const fmt = (d: Date) => d.toISOString();
+    const yesterday = new Date(today);
+    yesterday.setDate(today.getDate() - 1);
+    const twoDaysAgo = new Date(today);
+    twoDaysAgo.setDate(today.getDate() - 2);
+
+    const sessions: SessionRecord[] = [
+      makeSession({ id: "1", date: fmt(today) }),
+      makeSession({ id: "2", date: fmt(yesterday) }),
+      makeSession({ id: "3", date: fmt(twoDaysAgo) }),
+    ];
+    const streak = getWorkoutStreak(sessions);
+    expect(streak.current).toBe(3);
+    expect(streak.best).toBe(3);
+  });
+
+  it("treats multiple sessions on same day as 1 day", () => {
+    const today = new Date();
+    const sessions: SessionRecord[] = [
+      makeSession({ id: "1", date: today.toISOString() }),
+      makeSession({ id: "2", date: today.toISOString() }),
+    ];
+    const streak = getWorkoutStreak(sessions);
+    expect(streak.current).toBe(1);
+    expect(streak.best).toBe(1);
+  });
+
+  it("resets current streak if last session was >1 day ago", () => {
+    const threeDaysAgo = new Date();
+    threeDaysAgo.setDate(threeDaysAgo.getDate() - 3);
+    const fourDaysAgo = new Date();
+    fourDaysAgo.setDate(fourDaysAgo.getDate() - 4);
+
+    const sessions: SessionRecord[] = [
+      makeSession({ id: "1", date: threeDaysAgo.toISOString() }),
+      makeSession({ id: "2", date: fourDaysAgo.toISOString() }),
+    ];
+    const streak = getWorkoutStreak(sessions);
+    expect(streak.current).toBe(0);
+    expect(streak.best).toBe(2);
+  });
+});
+
+describe("getTotalReps", () => {
+  it("returns 0 for empty", () => {
+    expect(getTotalReps([])).toBe(0);
+  });
+
+  it("sums reps across sessions", () => {
+    const sessions: SessionRecord[] = [
+      makeSession({ id: "1", reps: 10 }),
+      makeSession({ id: "2", reps: 15 }),
+      makeSession({ id: "3", reps: 8 }),
+    ];
+    expect(getTotalReps(sessions)).toBe(33);
+  });
+});
+
+describe("getScoreTrend", () => {
+  it("returns 0 for first session of exercise", () => {
+    const session = makeSession({ id: "1", exercise: "squat", score: 80 });
+    expect(getScoreTrend([session], session)).toBe(0);
+  });
+
+  it("returns 1 when score improved", () => {
+    const sessions: SessionRecord[] = [
+      makeSession({ id: "2", exercise: "squat", score: 90 }),
+      makeSession({ id: "1", exercise: "squat", score: 80 }),
+    ];
+    expect(getScoreTrend(sessions, sessions[0])).toBe(1);
+  });
+
+  it("returns -1 when score declined", () => {
+    const sessions: SessionRecord[] = [
+      makeSession({ id: "2", exercise: "squat", score: 70 }),
+      makeSession({ id: "1", exercise: "squat", score: 80 }),
+    ];
+    expect(getScoreTrend(sessions, sessions[0])).toBe(-1);
+  });
+
+  it("returns 0 when score is same", () => {
+    const sessions: SessionRecord[] = [
+      makeSession({ id: "2", exercise: "squat", score: 80 }),
+      makeSession({ id: "1", exercise: "squat", score: 80 }),
+    ];
+    expect(getScoreTrend(sessions, sessions[0])).toBe(0);
+  });
+});

--- a/src/lib/sessionStorage.ts
+++ b/src/lib/sessionStorage.ts
@@ -1,5 +1,5 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import type { SessionRecord } from "./types";
+import type { Exercise, SessionRecord } from "./types";
 
 const STORAGE_KEY = "@gym_form_coach/sessions";
 const MAX_SESSIONS = 50;
@@ -45,4 +45,94 @@ export function findPreviousSession(
   return (
     sessions.find((s) => s.exercise === exercise && s.id !== currentId) ?? null
   );
+}
+
+/** Return the best form score + date for each exercise. */
+export function getPersonalBests(
+  sessions: SessionRecord[]
+): Partial<Record<Exercise, { score: number; date: string }>> {
+  const bests: Partial<Record<Exercise, { score: number; date: string }>> = {};
+  for (const s of sessions) {
+    const current = bests[s.exercise];
+    if (!current || s.score > current.score) {
+      bests[s.exercise] = { score: s.score, date: s.date };
+    }
+  }
+  return bests;
+}
+
+/** Count consecutive calendar days with at least 1 session, and best streak ever. */
+export function getWorkoutStreak(
+  sessions: SessionRecord[]
+): { current: number; best: number } {
+  if (sessions.length === 0) return { current: 0, best: 0 };
+
+  // Get unique dates (YYYY-MM-DD), sorted descending
+  const uniqueDays = [
+    ...new Set(sessions.map((s) => s.date.slice(0, 10))),
+  ].sort((a, b) => (a > b ? -1 : 1));
+
+  if (uniqueDays.length === 0) return { current: 0, best: 0 };
+
+  let current = 1;
+  let best = 1;
+  let streak = 1;
+
+  // Check if the most recent session day is today or yesterday (streak is still active)
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const mostRecent = new Date(uniqueDays[0] + "T00:00:00");
+  const daysSinceLast = Math.round(
+    (today.getTime() - mostRecent.getTime()) / 86400000
+  );
+
+  for (let i = 1; i < uniqueDays.length; i++) {
+    const prev = new Date(uniqueDays[i - 1] + "T00:00:00");
+    const curr = new Date(uniqueDays[i] + "T00:00:00");
+    const diff = Math.round((prev.getTime() - curr.getTime()) / 86400000);
+    if (diff === 1) {
+      streak++;
+    } else {
+      if (streak > best) best = streak;
+      streak = 1;
+    }
+  }
+  if (streak > best) best = streak;
+
+  // Current streak: only count if most recent day is today or yesterday
+  if (daysSinceLast <= 1) {
+    // Walk from the start to find the current streak length
+    current = 1;
+    for (let i = 1; i < uniqueDays.length; i++) {
+      const prev = new Date(uniqueDays[i - 1] + "T00:00:00");
+      const curr = new Date(uniqueDays[i] + "T00:00:00");
+      const diff = Math.round((prev.getTime() - curr.getTime()) / 86400000);
+      if (diff === 1) {
+        current++;
+      } else {
+        break;
+      }
+    }
+  } else {
+    current = 0;
+  }
+
+  return { current, best };
+}
+
+/** Total reps across all sessions. */
+export function getTotalReps(sessions: SessionRecord[]): number {
+  return sessions.reduce((sum, s) => sum + s.reps, 0);
+}
+
+/** Score trend: compare to previous session of same exercise. Returns 1 (up), -1 (down), or 0 (same/first). */
+export function getScoreTrend(
+  sessions: SessionRecord[],
+  session: SessionRecord
+): number {
+  const prev = findPreviousSession(sessions, session.exercise, session.id);
+  if (!prev) return 0;
+  if (session.score > prev.score) return 1;
+  if (session.score < prev.score) return -1;
+  return 0;
 }

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -8,18 +8,23 @@ import {
   TouchableOpacity,
   Alert,
   Pressable,
+  ScrollView,
 } from "react-native";
 import { useFocusEffect } from "@react-navigation/native";
-import type { SessionRecord } from "../lib/types";
+import type { Exercise, SessionRecord } from "../lib/types";
 import { EXERCISE_LABELS, FLAG_LABELS } from "../lib/types";
 import {
   loadSessions,
   findPreviousSession,
   deleteSession,
   clearAllSessions,
+  getPersonalBests,
+  getWorkoutStreak,
+  getTotalReps,
+  getScoreTrend,
 } from "../lib/sessionStorage";
 
-const MAX_DISPLAY = 10;
+const MAX_DISPLAY = 50;
 
 function formatDate(iso: string): string {
   const d = new Date(iso);
@@ -28,6 +33,14 @@ function formatDate(iso: string): string {
     day: "numeric",
     hour: "2-digit",
     minute: "2-digit",
+  });
+}
+
+function formatShortDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
   });
 }
 
@@ -60,14 +73,96 @@ function DeltaBadge({
   );
 }
 
+function ScoreTrendArrow({ trend }: { trend: number }) {
+  if (trend === 0) return <Text style={styles.trendNeutral}>—</Text>;
+  if (trend > 0) return <Text style={styles.trendUp}>▲</Text>;
+  return <Text style={styles.trendDown}>▼</Text>;
+}
+
+function StatsHeader({ sessions }: { sessions: SessionRecord[] }) {
+  if (sessions.length === 0) return null;
+
+  const totalReps = getTotalReps(sessions);
+  const streak = getWorkoutStreak(sessions);
+
+  return (
+    <View style={styles.statsHeader}>
+      <View style={styles.statBox}>
+        <Text style={styles.statValue}>{sessions.length}</Text>
+        <Text style={styles.statLabel}>Sessions</Text>
+      </View>
+      <View style={styles.statBox}>
+        <Text style={styles.statValue}>{totalReps}</Text>
+        <Text style={styles.statLabel}>Total Reps</Text>
+      </View>
+      <View style={styles.statBox}>
+        <Text style={styles.statValue}>{streak.current}</Text>
+        <Text style={styles.statLabel}>Day Streak</Text>
+      </View>
+      <View style={styles.statBox}>
+        <Text style={styles.statValue}>{streak.best}</Text>
+        <Text style={styles.statLabel}>Best Streak</Text>
+      </View>
+    </View>
+  );
+}
+
+function PersonalBests({
+  sessions,
+  exerciseFilter,
+  onFilterChange,
+}: {
+  sessions: SessionRecord[];
+  exerciseFilter: Exercise | null;
+  onFilterChange: (exercise: Exercise | null) => void;
+}) {
+  const bests = getPersonalBests(sessions);
+  const exercises = Object.keys(bests) as Exercise[];
+  if (exercises.length === 0) return null;
+
+  return (
+    <View style={styles.bestsSection}>
+      <Text style={styles.bestsTitle}>Personal Bests</Text>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.bestsRow}
+      >
+        {exercises.map((ex) => {
+          const best = bests[ex]!;
+          const isActive = exerciseFilter === ex;
+          return (
+            <Pressable
+              key={ex}
+              style={[styles.bestCard, isActive && styles.bestCardActive]}
+              onPress={() => onFilterChange(isActive ? null : ex)}
+            >
+              <Text style={styles.bestExercise}>
+                {EXERCISE_LABELS[ex] ?? ex}
+              </Text>
+              <Text style={styles.bestScore}>{best.score}%</Text>
+              <Text style={styles.bestDate}>{formatShortDate(best.date)}</Text>
+            </Pressable>
+          );
+        })}
+      </ScrollView>
+    </View>
+  );
+}
+
 export default function HistoryScreen() {
-  const [sessions, setSessions] = useState<SessionRecord[]>([]);
+  const [allSessions, setAllSessions] = useState<SessionRecord[]>([]);
+  const [exerciseFilter, setExerciseFilter] = useState<Exercise | null>(null);
 
   const refresh = useCallback(() => {
-    loadSessions().then((s) => setSessions(s.slice(0, MAX_DISPLAY)));
+    loadSessions().then((s) => setAllSessions(s.slice(0, MAX_DISPLAY)));
   }, []);
 
   useFocusEffect(refresh);
+
+  const filteredSessions = exerciseFilter
+    ? allSessions.filter((s) => s.exercise === exerciseFilter)
+    : allSessions;
 
   const handleDeleteSession = useCallback(
     (id: string) => {
@@ -104,40 +199,67 @@ export default function HistoryScreen() {
     );
   }, [refresh]);
 
-  const renderItem = ({ item }: { item: SessionRecord }) => (
-    <View style={styles.sessionCard}>
-      <View style={styles.sessionHeader}>
-        <Text style={styles.exerciseLabel}>
-          {EXERCISE_LABELS[item.exercise] ?? item.exercise}
-        </Text>
-        <View style={styles.sessionHeaderRight}>
-          <Text style={styles.dateLabel}>{formatDate(item.date)}</Text>
-          <Pressable
-            onPress={() => handleDeleteSession(item.id)}
-            style={({ pressed }) => [
-              styles.deleteButton,
-              pressed && styles.deleteButtonPressed,
-            ]}
-            accessibilityLabel="Delete session"
-            accessibilityRole="button"
-          >
-            <Text style={styles.deleteButtonText}>✕</Text>
+  const renderItem = ({ item }: { item: SessionRecord }) => {
+    const trend = getScoreTrend(allSessions, item);
+    return (
+      <View style={styles.sessionCard}>
+        <View style={styles.sessionHeader}>
+          <Text style={styles.exerciseLabel}>
+            {EXERCISE_LABELS[item.exercise] ?? item.exercise}
+          </Text>
+          <View style={styles.sessionHeaderRight}>
+            <Text style={styles.dateLabel}>{formatDate(item.date)}</Text>
+            <Pressable
+              onPress={() => handleDeleteSession(item.id)}
+              style={({ pressed }) => [
+                styles.deleteButton,
+                pressed && styles.deleteButtonPressed,
+              ]}
+              accessibilityLabel="Delete session"
+              accessibilityRole="button"
+            >
+              <Text style={styles.deleteButtonText}>✕</Text>
+            </Pressable>
+          </View>
+        </View>
+
+        <View style={styles.sessionStats}>
+          <Text style={styles.repCount}>{item.reps} reps</Text>
+          <View style={styles.scoreRow}>
+            <Text style={styles.scoreText}>{item.score}%</Text>
+            <ScoreTrendArrow trend={trend} />
+          </View>
+          <DeltaBadge sessions={allSessions} session={item} />
+        </View>
+
+        {item.topFlag && (
+          <Text style={styles.flagLabel}>
+            {FLAG_LABELS[item.topFlag] ?? item.topFlag}
+          </Text>
+        )}
+      </View>
+    );
+  };
+
+  const ListHeader = () => (
+    <>
+      <StatsHeader sessions={allSessions} />
+      <PersonalBests
+        sessions={allSessions}
+        exerciseFilter={exerciseFilter}
+        onFilterChange={setExerciseFilter}
+      />
+      {exerciseFilter && (
+        <View style={styles.filterBanner}>
+          <Text style={styles.filterText}>
+            Showing: {EXERCISE_LABELS[exerciseFilter]}
+          </Text>
+          <Pressable onPress={() => setExerciseFilter(null)}>
+            <Text style={styles.filterClear}>Clear</Text>
           </Pressable>
         </View>
-      </View>
-
-      <View style={styles.sessionStats}>
-        <Text style={styles.repCount}>{item.reps} reps</Text>
-        <Text style={styles.scoreText}>{item.score}%</Text>
-        <DeltaBadge sessions={sessions} session={item} />
-      </View>
-
-      {item.topFlag && (
-        <Text style={styles.flagLabel}>
-          {FLAG_LABELS[item.topFlag] ?? item.topFlag}
-        </Text>
       )}
-    </View>
+    </>
   );
 
   return (
@@ -145,7 +267,7 @@ export default function HistoryScreen() {
       <View style={styles.header}>
         <View style={styles.headerTop}>
           <Text style={styles.title}>Session History</Text>
-          {sessions.length > 0 && (
+          {allSessions.length > 0 && (
             <TouchableOpacity
               onPress={handleClearAll}
               style={styles.clearAllButton}
@@ -156,10 +278,9 @@ export default function HistoryScreen() {
             </TouchableOpacity>
           )}
         </View>
-        <Text style={styles.subtitle}>Last {MAX_DISPLAY} sessions</Text>
       </View>
 
-      {sessions.length === 0 ? (
+      {allSessions.length === 0 ? (
         <View style={styles.emptyState}>
           <Text style={styles.emptyTitle}>No sessions yet</Text>
           <Text style={styles.emptySubtitle}>
@@ -168,9 +289,10 @@ export default function HistoryScreen() {
         </View>
       ) : (
         <FlatList
-          data={sessions}
+          data={filteredSessions}
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
+          ListHeaderComponent={ListHeader}
           contentContainerStyle={styles.list}
           showsVerticalScrollIndicator={false}
         />
@@ -199,11 +321,6 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     color: "#ffffff",
   },
-  subtitle: {
-    fontSize: 14,
-    color: "#ffffff50",
-    marginTop: 4,
-  },
   clearAllButton: {
     paddingHorizontal: 12,
     paddingVertical: 6,
@@ -216,6 +333,96 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: "#ef4444",
   },
+  // Stats Header
+  statsHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    marginBottom: 20,
+  },
+  statBox: {
+    flex: 1,
+    backgroundColor: "#1a1a24",
+    borderRadius: 10,
+    paddingVertical: 12,
+    marginHorizontal: 3,
+    alignItems: "center",
+  },
+  statValue: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#ffffff",
+  },
+  statLabel: {
+    fontSize: 11,
+    color: "#ffffff50",
+    marginTop: 4,
+  },
+  // Personal Bests
+  bestsSection: {
+    marginBottom: 20,
+  },
+  bestsTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ffffff60",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 10,
+  },
+  bestsRow: {
+    gap: 10,
+  },
+  bestCard: {
+    backgroundColor: "#1a1a24",
+    borderRadius: 12,
+    paddingHorizontal: 18,
+    paddingVertical: 14,
+    minWidth: 110,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "transparent",
+  },
+  bestCardActive: {
+    borderColor: "#00E5FF",
+  },
+  bestExercise: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ffffff80",
+    marginBottom: 6,
+  },
+  bestScore: {
+    fontSize: 22,
+    fontWeight: "700",
+    color: "#6366f1",
+  },
+  bestDate: {
+    fontSize: 11,
+    color: "#ffffff40",
+    marginTop: 4,
+  },
+  // Filter banner
+  filterBanner: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    backgroundColor: "#00E5FF15",
+    borderRadius: 8,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    marginBottom: 14,
+  },
+  filterText: {
+    fontSize: 13,
+    color: "#00E5FF",
+    fontWeight: "600",
+  },
+  filterClear: {
+    fontSize: 13,
+    color: "#ffffff60",
+    fontWeight: "500",
+  },
+  // Session list
   list: {
     paddingHorizontal: 20,
     paddingBottom: 40,
@@ -273,10 +480,27 @@ const styles = StyleSheet.create({
     fontWeight: "600",
     color: "#ffffffcc",
   },
+  scoreRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+  },
   scoreText: {
     fontSize: 15,
     color: "#6366f1",
     fontWeight: "600",
+  },
+  trendUp: {
+    fontSize: 12,
+    color: "#22c55e",
+  },
+  trendDown: {
+    fontSize: 12,
+    color: "#ef4444",
+  },
+  trendNeutral: {
+    fontSize: 12,
+    color: "#ffffff40",
   },
   deltaBadge: {
     paddingHorizontal: 8,


### PR DESCRIPTION
## Summary
- Stats header on History screen: total sessions, total reps, current/best workout streak
- Personal bests cards per exercise (tap to filter session list)
- Score trend arrows (▲/▼/—) on each session row comparing to previous session of same exercise
- 5 pure helper functions in `sessionStorage.ts` with 12 unit tests

## Test plan
- [ ] History screen shows stats when sessions exist
- [ ] Personal bests show correct highest score per exercise
- [ ] Tapping a PB card filters the session list; tapping again clears filter
- [ ] Score arrows correctly show improvement/decline/same
- [ ] Streak counts consecutive calendar days, not individual sessions
- [ ] `npm test` passes (40 tests)
- [ ] `npx tsc --noEmit` clean

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)