### PR TITLE
feat: add overhead press as fourth exercise

### DIFF
--- a/src/__tests__/overheadPress.test.ts
+++ b/src/__tests__/overheadPress.test.ts
@@ -1,0 +1,151 @@
+import {
+  createOverheadPressState,
+  processOverheadPressFrame,
+  type OverheadPressState,
+} from "../lib/formAnalysis/overheadPress";
+import { buildPose, KP } from "./testHelpers";
+
+/**
+ * Build a pose for overhead press positions.
+ * Standing person facing camera:
+ * - Shoulders at y=200, hips at y=350, ankles at y=500
+ * - Wrists position varies by phase
+ */
+function bottomPose() {
+  // Bar at shoulder height — wrists near shoulders
+  return buildPose({
+    [KP.LEFT_SHOULDER]: { x: 120, y: 200 },
+    [KP.RIGHT_SHOULDER]: { x: 180, y: 200 },
+    [KP.LEFT_ELBOW]: { x: 110, y: 220 },
+    [KP.RIGHT_ELBOW]: { x: 190, y: 220 },
+    [KP.LEFT_WRIST]: { x: 115, y: 195 },
+    [KP.RIGHT_WRIST]: { x: 185, y: 195 },
+    [KP.LEFT_HIP]: { x: 130, y: 350 },
+    [KP.RIGHT_HIP]: { x: 170, y: 350 },
+    [KP.LEFT_ANKLE]: { x: 130, y: 500 },
+    [KP.RIGHT_ANKLE]: { x: 170, y: 500 },
+  });
+}
+
+function lockoutPose() {
+  // Arms fully extended overhead — wrists well above shoulders, elbows straight
+  return buildPose({
+    [KP.LEFT_SHOULDER]: { x: 120, y: 200 },
+    [KP.RIGHT_SHOULDER]: { x: 180, y: 200 },
+    [KP.LEFT_ELBOW]: { x: 120, y: 130 },
+    [KP.RIGHT_ELBOW]: { x: 180, y: 130 },
+    [KP.LEFT_WRIST]: { x: 120, y: 60 },
+    [KP.RIGHT_WRIST]: { x: 180, y: 60 },
+    [KP.LEFT_HIP]: { x: 130, y: 350 },
+    [KP.RIGHT_HIP]: { x: 170, y: 350 },
+    [KP.LEFT_ANKLE]: { x: 130, y: 500 },
+    [KP.RIGHT_ANKLE]: { x: 170, y: 500 },
+  });
+}
+
+function pressingPose() {
+  // Mid-press — wrists above shoulders but elbows still bent
+  return buildPose({
+    [KP.LEFT_SHOULDER]: { x: 120, y: 200 },
+    [KP.RIGHT_SHOULDER]: { x: 180, y: 200 },
+    [KP.LEFT_ELBOW]: { x: 115, y: 155 },
+    [KP.RIGHT_ELBOW]: { x: 185, y: 155 },
+    [KP.LEFT_WRIST]: { x: 120, y: 110 },
+    [KP.RIGHT_WRIST]: { x: 180, y: 110 },
+    [KP.LEFT_HIP]: { x: 130, y: 350 },
+    [KP.RIGHT_HIP]: { x: 170, y: 350 },
+    [KP.LEFT_ANKLE]: { x: 130, y: 500 },
+    [KP.RIGHT_ANKLE]: { x: 170, y: 500 },
+  });
+}
+
+function runFrames(
+  poses: ReturnType<typeof buildPose>[],
+  initialState?: OverheadPressState
+) {
+  let state = initialState ?? createOverheadPressState();
+  const events: { completedRep: boolean; flag: string | null }[] = [];
+
+  for (const pose of poses) {
+    const result = processOverheadPressFrame(pose, state);
+    state = result.state;
+    if (result.completedRep) {
+      events.push({ completedRep: true, flag: result.flag });
+    }
+  }
+
+  return { state, events };
+}
+
+describe("overheadPress", () => {
+  it("starts with zero reps", () => {
+    const state = createOverheadPressState();
+    expect(state.repCount).toBe(0);
+    expect(state.phase).toBe("bottom");
+  });
+
+  it("counts a full rep cycle", () => {
+    // bottom → press up → lockout → lower (1 frame) → bottom (completes)
+    const { state, events } = runFrames([
+      bottomPose(),
+      pressingPose(),
+      lockoutPose(),
+      bottomPose(), // transitions top → lowering
+      bottomPose(), // transitions lowering → complete
+    ]);
+
+    expect(events.length).toBe(1);
+    expect(events[0].completedRep).toBe(true);
+    expect(state.repCount).toBe(1);
+  });
+
+  it("counts multiple reps", () => {
+    const cycle = [
+      bottomPose(),
+      pressingPose(),
+      lockoutPose(),
+      bottomPose(), // top → lowering
+      bottomPose(), // lowering → complete
+    ];
+    const { state, events } = runFrames([...cycle, ...cycle, ...cycle]);
+
+    expect(events.length).toBe(3);
+    expect(state.repCount).toBe(3);
+  });
+
+  it("returns null when keypoints are missing", () => {
+    const emptyPose = buildPose({});
+    const state = createOverheadPressState();
+    const result = processOverheadPressFrame(emptyPose, state);
+    expect(result.completedRep).toBe(false);
+    expect(result.flag).toBeNull();
+  });
+
+  it("detects uneven press flag", () => {
+    // One wrist much higher than the other during press
+    const unevenPose = buildPose({
+      [KP.LEFT_SHOULDER]: { x: 120, y: 200 },
+      [KP.RIGHT_SHOULDER]: { x: 180, y: 200 },
+      [KP.LEFT_ELBOW]: { x: 120, y: 130 },
+      [KP.RIGHT_ELBOW]: { x: 180, y: 160 },
+      [KP.LEFT_WRIST]: { x: 120, y: 60 },
+      [KP.RIGHT_WRIST]: { x: 180, y: 120 }, // much lower than left
+      [KP.LEFT_HIP]: { x: 130, y: 350 },
+      [KP.RIGHT_HIP]: { x: 170, y: 350 },
+      [KP.LEFT_ANKLE]: { x: 130, y: 500 },
+      [KP.RIGHT_ANKLE]: { x: 170, y: 500 },
+    });
+
+    const { events } = runFrames([
+      bottomPose(),
+      pressingPose(), // bottom → pressing
+      unevenPose,     // pressing phase, collects uneven_press flag
+      lockoutPose(),  // pressing → top
+      bottomPose(),   // top → lowering
+      bottomPose(),   // lowering → complete
+    ]);
+
+    expect(events.length).toBe(1);
+    expect(events[0].flag).toBe("uneven_press");
+  });
+});

--- a/src/components/CameraGuide.tsx
+++ b/src/components/CameraGuide.tsx
@@ -21,6 +21,8 @@ const GUIDE_TEXT: Record<Exercise, string> = {
     "Place your phone 6–8 feet away at hip height, angled to see your side profile. Ensure the bar and your full body are visible.",
   pushup:
     "Place your phone 3–4 feet away at floor level, angled to see your side profile. Ensure your full body is visible.",
+  overheadPress:
+    "Place your phone 6–8 feet away at waist height, facing you front-on. Ensure your full body from feet to hands overhead is visible.",
 };
 
 export default function CameraGuide({ exercise, onReady }: CameraGuideProps) {

--- a/src/hooks/useRepDetector.ts
+++ b/src/hooks/useRepDetector.ts
@@ -16,6 +16,11 @@ import {
   processPushupFrame,
   type PushupState,
 } from "../lib/formAnalysis/pushup";
+import {
+  createOverheadPressState,
+  processOverheadPressFrame,
+  type OverheadPressState,
+} from "../lib/formAnalysis/overheadPress";
 
 export interface RepEvent {
   repNumber: number;
@@ -26,6 +31,7 @@ interface RepDetectorState {
   squat: SquatState;
   deadlift: DeadliftState;
   pushup: PushupState;
+  overheadPress: OverheadPressState;
 }
 
 export function useRepDetector(exercise: Exercise) {
@@ -33,6 +39,7 @@ export function useRepDetector(exercise: Exercise) {
     squat: createSquatState(),
     deadlift: createDeadliftState(),
     pushup: createPushupState(),
+    overheadPress: createOverheadPressState(),
   });
 
   const totalReps = useRef(0);
@@ -58,6 +65,12 @@ export function useRepDetector(exercise: Exercise) {
         case "pushup": {
           const r = processPushupFrame(pose, stateRef.current.pushup);
           stateRef.current.pushup = r.state;
+          result = r;
+          break;
+        }
+        case "overheadPress": {
+          const r = processOverheadPressFrame(pose, stateRef.current.overheadPress);
+          stateRef.current.overheadPress = r.state;
           result = r;
           break;
         }
@@ -91,6 +104,7 @@ export function useRepDetector(exercise: Exercise) {
       squat: createSquatState(),
       deadlift: createDeadliftState(),
       pushup: createPushupState(),
+      overheadPress: createOverheadPressState(),
     };
     totalReps.current = 0;
     flagCounts.current = {};

--- a/src/lib/formAnalysis/overheadPress.ts
+++ b/src/lib/formAnalysis/overheadPress.ts
@@ -1,0 +1,208 @@
+import type { Keypoint, Pose } from "@tensorflow-models/pose-detection";
+import type { FormFlag } from "../types";
+import { angleDeg, getKeypoint } from "../mathUtils";
+
+// COCO keypoint indices
+const LEFT_SHOULDER = 5;
+const RIGHT_SHOULDER = 6;
+const LEFT_ELBOW = 7;
+const RIGHT_ELBOW = 8;
+const LEFT_WRIST = 9;
+const RIGHT_WRIST = 10;
+const LEFT_HIP = 11;
+const RIGHT_HIP = 12;
+const LEFT_ANKLE = 15;
+const RIGHT_ANKLE = 16;
+
+type RepPhase = "bottom" | "pressing" | "top" | "lowering";
+
+export interface OverheadPressState {
+  phase: RepPhase;
+  repCount: number;
+  currentRepFlags: FormFlag[];
+}
+
+export function createOverheadPressState(): OverheadPressState {
+  return {
+    phase: "bottom",
+    repCount: 0,
+    currentRepFlags: [],
+  };
+}
+
+function midpointY(a: Keypoint, b: Keypoint): number {
+  return (a.y + b.y) / 2;
+}
+
+/**
+ * Detect form flags for the current frame.
+ */
+function detectFlags(pose: Pose): FormFlag[] {
+  const flags: FormFlag[] = [];
+
+  const lShoulder = getKeypoint(pose, LEFT_SHOULDER);
+  const rShoulder = getKeypoint(pose, RIGHT_SHOULDER);
+  const lElbow = getKeypoint(pose, LEFT_ELBOW);
+  const rElbow = getKeypoint(pose, RIGHT_ELBOW);
+  const lWrist = getKeypoint(pose, LEFT_WRIST);
+  const rWrist = getKeypoint(pose, RIGHT_WRIST);
+  const lHip = getKeypoint(pose, LEFT_HIP);
+  const rHip = getKeypoint(pose, RIGHT_HIP);
+  const lAnkle = getKeypoint(pose, LEFT_ANKLE);
+  const rAnkle = getKeypoint(pose, RIGHT_ANKLE);
+
+  // 1. Excessive back arch: hip-shoulder-ankle angle (side view)
+  // In a straight standing position, this angle should be ~180
+  // A large arch means the hips push forward, reducing this angle
+  if (lShoulder && lHip && lAnkle) {
+    const backAngle = angleDeg(lShoulder, lHip, lAnkle);
+    if (backAngle < 160) {
+      flags.push("excessive_back_arch");
+    }
+  } else if (rShoulder && rHip && rAnkle) {
+    const backAngle = angleDeg(rShoulder, rHip, rAnkle);
+    if (backAngle < 160) {
+      flags.push("excessive_back_arch");
+    }
+  }
+
+  // 2. Uneven press: one wrist significantly higher than the other at lockout
+  if (lWrist && rWrist) {
+    const yDiff = Math.abs(lWrist.y - rWrist.y);
+    if (yDiff > 25) {
+      flags.push("uneven_press");
+    }
+  }
+
+  // 3. Incomplete lockout: elbow not fully extended at top
+  // Check if wrists are above shoulders (at lockout position)
+  if (lShoulder && lWrist && rShoulder && rWrist) {
+    const wristAbove =
+      lWrist.y < lShoulder.y - 20 || rWrist.y < rShoulder.y - 20;
+    if (wristAbove) {
+      // At or near lockout — check elbow angle
+      if (lShoulder && lElbow && lWrist) {
+        const elbowAngle = angleDeg(lShoulder, lElbow, lWrist);
+        if (elbowAngle < 160) {
+          flags.push("incomplete_lockout");
+        }
+      } else if (rShoulder && rElbow && rWrist) {
+        const elbowAngle = angleDeg(rShoulder, rElbow, rWrist);
+        if (elbowAngle < 160) {
+          flags.push("incomplete_lockout");
+        }
+      }
+    }
+  }
+
+  return flags;
+}
+
+/**
+ * Process a new pose frame and update overhead press state.
+ * Returns the flag for the just-completed rep, or null if no rep completed.
+ *
+ * Rep phases:
+ * - bottom: bar at shoulder height (wrists near shoulders)
+ * - pressing: wrists moving above shoulders
+ * - top: arms locked out overhead (wrists well above shoulders, elbows extended)
+ * - lowering: wrists descending back toward shoulders
+ */
+export function processOverheadPressFrame(
+  pose: Pose,
+  state: OverheadPressState
+): { completedRep: boolean; flag: FormFlag | null; state: OverheadPressState } {
+  const lShoulder = getKeypoint(pose, LEFT_SHOULDER);
+  const rShoulder = getKeypoint(pose, RIGHT_SHOULDER);
+  const lWrist = getKeypoint(pose, LEFT_WRIST);
+  const rWrist = getKeypoint(pose, RIGHT_WRIST);
+  const lElbow = getKeypoint(pose, LEFT_ELBOW);
+  const rElbow = getKeypoint(pose, RIGHT_ELBOW);
+
+  // Need at least one side of shoulder + wrist visible
+  if ((!lShoulder && !rShoulder) || (!lWrist && !rWrist)) {
+    return { completedRep: false, flag: null, state };
+  }
+
+  const shoulderY =
+    lShoulder && rShoulder
+      ? midpointY(lShoulder, rShoulder)
+      : (lShoulder ?? rShoulder)!.y;
+  const wristY =
+    lWrist && rWrist ? midpointY(lWrist, rWrist) : (lWrist ?? rWrist)!.y;
+
+  // Elbow angle for lockout detection
+  const elbowAngle = (() => {
+    if (lShoulder && lElbow && lWrist) return angleDeg(lShoulder, lElbow, lWrist);
+    if (rShoulder && rElbow && rWrist) return angleDeg(rShoulder, rElbow, rWrist);
+    return null;
+  })();
+
+  // In image space, Y increases downward
+  // wristY < shoulderY means wrists are above shoulders
+  const wristAboveShoulder = wristY < shoulderY - 20;
+  const wristAtShoulder = Math.abs(wristY - shoulderY) < 40;
+  const armsLockedOut = elbowAngle !== null && elbowAngle > 155;
+
+  const newState = { ...state };
+
+  switch (state.phase) {
+    case "bottom": {
+      // Detect press start: wrists moving above shoulders
+      if (wristAboveShoulder) {
+        newState.phase = "pressing";
+        newState.currentRepFlags = [];
+      }
+      break;
+    }
+
+    case "pressing": {
+      // Collect flags during press
+      const frameFlags = detectFlags(pose);
+      for (const f of frameFlags) {
+        if (!newState.currentRepFlags.includes(f)) {
+          newState.currentRepFlags.push(f);
+        }
+      }
+
+      // Check if reached top (arms locked out, wrists well above shoulders)
+      if (wristAboveShoulder && armsLockedOut) {
+        newState.phase = "top";
+      }
+      break;
+    }
+
+    case "top": {
+      // Collect flags at top
+      const frameFlags = detectFlags(pose);
+      for (const f of frameFlags) {
+        if (!newState.currentRepFlags.includes(f)) {
+          newState.currentRepFlags.push(f);
+        }
+      }
+
+      // Detect lowering: wrists coming back down
+      if (!wristAboveShoulder) {
+        newState.phase = "lowering";
+      }
+      break;
+    }
+
+    case "lowering": {
+      // Rep completes when wrists return to shoulder height
+      if (wristAtShoulder) {
+        newState.repCount += 1;
+        newState.phase = "bottom";
+
+        // Pick the most important flag
+        const flag = newState.currentRepFlags[0] ?? null;
+        newState.currentRepFlags = [];
+
+        return { completedRep: true, flag, state: newState };
+      }
+      break;
+    }
+  }
+
+  return { completedRep: false, flag: null, state: newState };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,4 +1,4 @@
-export type Exercise = "squat" | "deadlift" | "pushup";
+export type Exercise = "squat" | "deadlift" | "pushup" | "overheadPress";
 
 export type FormFlag =
   | "knees_caving"
@@ -9,7 +9,10 @@ export type FormFlag =
   | "bar_drift"
   | "hips_sagging"
   | "elbows_flaring"
-  | "incomplete_range";
+  | "incomplete_range"
+  | "excessive_back_arch"
+  | "uneven_press"
+  | "incomplete_lockout";
 
 export interface SessionRecord {
   id: string;
@@ -30,6 +33,9 @@ export const FLAG_LABELS: Record<FormFlag, string> = {
   hips_sagging: "Hips sagging",
   elbows_flaring: "Elbows flaring out",
   incomplete_range: "Incomplete range of motion",
+  excessive_back_arch: "Excessive back arch",
+  uneven_press: "Uneven press",
+  incomplete_lockout: "Incomplete lockout",
 };
 
 export const DRILL_SUGGESTIONS: Record<FormFlag, string> = {
@@ -42,10 +48,14 @@ export const DRILL_SUGGESTIONS: Record<FormFlag, string> = {
   hips_sagging: "Strengthen your core with planks and dead bugs",
   elbows_flaring: "Tuck elbows at 45° — try diamond push-ups to build the pattern",
   incomplete_range: "Slow down — use tempo push-ups (3 seconds down, 3 up)",
+  excessive_back_arch: "Brace your core harder — practice with wall-supported presses",
+  uneven_press: "Focus on pressing evenly — try single-arm dumbbell presses to find imbalances",
+  incomplete_lockout: "Press until elbows are fully locked — use lighter weight to build the pattern",
 };
 
 export const EXERCISE_LABELS: Record<Exercise, string> = {
   squat: "Squat",
   deadlift: "Deadlift",
   pushup: "Push-up",
+  overheadPress: "Overhead Press",
 };

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -20,6 +20,7 @@ const EXERCISES: { type: Exercise; emoji: string; description: string }[] = [
   { type: "squat", emoji: "🏋️", description: "Track depth, knee path & lean" },
   { type: "deadlift", emoji: "💪", description: "Track back angle & bar path" },
   { type: "pushup", emoji: "🫸", description: "Track range, hips & elbows" },
+  { type: "overheadPress", emoji: "🙌", description: "Track lockout, arch & symmetry" },
 ];
 
 export default function HomeScreen({ navigation }: HomeProps) {


### PR DESCRIPTION
## Summary
- New `overheadPress` exercise with full form analysis module
- Rep detection: shoulder height → lockout overhead → lower back
- 3 form flags: excessive back arch, uneven press, incomplete lockout
- Added to Home screen picker, CameraGuide, and useRepDetector
- 5 unit tests for the new module

## Test plan
- [ ] Overhead press appears in exercise picker on Home screen
- [ ] Camera guide shows front-facing placement hint for overhead press
- [ ] Rep detection counts press reps correctly
- [ ] Form flags detected: back arch, uneven press, incomplete lockout
- [ ] Audio cues fire for detected flags
- [ ] Summary and History screens display overhead press sessions correctly
- [ ] `npm test` passes (45 tests)
- [ ] `npx tsc --noEmit` clean

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)