### PR TITLE
feat: rep-by-rep form breakdown on Summary screen

### DIFF
--- a/src/__tests__/formInsights.test.ts
+++ b/src/__tests__/formInsights.test.ts
@@ -1,0 +1,85 @@
+import type { RepRecord } from "../lib/types";
+import { detectFatigue, findBestWorstReps } from "../lib/formInsights";
+
+describe("detectFatigue", () => {
+  it("returns not detected for fewer than 6 reps", () => {
+    const reps: RepRecord[] = [
+      { repNumber: 1, flag: null },
+      { repNumber: 2, flag: null },
+      { repNumber: 3, flag: "knees_caving" },
+    ];
+    expect(detectFatigue(reps).detected).toBe(false);
+  });
+
+  it("returns not detected when form is consistent", () => {
+    const reps: RepRecord[] = [
+      { repNumber: 1, flag: null },
+      { repNumber: 2, flag: null },
+      { repNumber: 3, flag: null },
+      { repNumber: 4, flag: null },
+      { repNumber: 5, flag: null },
+      { repNumber: 6, flag: null },
+    ];
+    expect(detectFatigue(reps).detected).toBe(false);
+  });
+
+  it("detects fatigue when late reps have more flags", () => {
+    const reps: RepRecord[] = [
+      { repNumber: 1, flag: null },
+      { repNumber: 2, flag: null },
+      { repNumber: 3, flag: null },
+      { repNumber: 4, flag: "knees_caving" },
+      { repNumber: 5, flag: "depth_too_shallow" },
+      { repNumber: 6, flag: "knees_caving" },
+      { repNumber: 7, flag: "forward_lean" },
+      { repNumber: 8, flag: "knees_caving" },
+    ];
+    const result = detectFatigue(reps);
+    expect(result.detected).toBe(true);
+    expect(result.message).toContain("form declined");
+  });
+
+  it("does not detect fatigue when early reps also have flags", () => {
+    const reps: RepRecord[] = [
+      { repNumber: 1, flag: "knees_caving" },
+      { repNumber: 2, flag: "forward_lean" },
+      { repNumber: 3, flag: "knees_caving" },
+      { repNumber: 4, flag: "knees_caving" },
+      { repNumber: 5, flag: "forward_lean" },
+      { repNumber: 6, flag: "knees_caving" },
+    ];
+    // first3 flags = 3, last3 flags = 3, diff = 0
+    expect(detectFatigue(reps).detected).toBe(false);
+  });
+});
+
+describe("findBestWorstReps", () => {
+  it("returns nulls for empty records", () => {
+    expect(findBestWorstReps([])).toEqual({ bestRep: null, worstRep: null });
+  });
+
+  it("finds best (no flag) and worst (has flag) reps", () => {
+    const reps: RepRecord[] = [
+      { repNumber: 1, flag: "knees_caving" },
+      { repNumber: 2, flag: null },
+      { repNumber: 3, flag: "forward_lean" },
+    ];
+    expect(findBestWorstReps(reps)).toEqual({ bestRep: 2, worstRep: 1 });
+  });
+
+  it("returns null for best if all reps have flags", () => {
+    const reps: RepRecord[] = [
+      { repNumber: 1, flag: "knees_caving" },
+      { repNumber: 2, flag: "forward_lean" },
+    ];
+    expect(findBestWorstReps(reps)).toEqual({ bestRep: null, worstRep: 1 });
+  });
+
+  it("returns null for worst if all reps are clean", () => {
+    const reps: RepRecord[] = [
+      { repNumber: 1, flag: null },
+      { repNumber: 2, flag: null },
+    ];
+    expect(findBestWorstReps(reps)).toEqual({ bestRep: 1, worstRep: null });
+  });
+});

--- a/src/hooks/useRepDetector.ts
+++ b/src/hooks/useRepDetector.ts
@@ -1,6 +1,6 @@
 import { useRef, useCallback } from "react";
 import type { Pose } from "@tensorflow-models/pose-detection";
-import type { Exercise, FormFlag } from "../lib/types";
+import type { Exercise, FormFlag, RepRecord } from "../lib/types";
 import {
   createSquatState,
   processSquatFrame,
@@ -44,6 +44,7 @@ export function useRepDetector(exercise: Exercise) {
 
   const totalReps = useRef(0);
   const flagCounts = useRef<Partial<Record<FormFlag, number>>>({});
+  const repRecords = useRef<RepRecord[]>([]);
 
   const processPose = useCallback(
     (pose: Pose): RepEvent | null => {
@@ -82,6 +83,10 @@ export function useRepDetector(exercise: Exercise) {
           flagCounts.current[result.flag] =
             (flagCounts.current[result.flag] ?? 0) + 1;
         }
+        repRecords.current.push({
+          repNumber: totalReps.current,
+          flag: result.flag,
+        });
         return { repNumber: totalReps.current, flag: result.flag };
       }
 
@@ -96,6 +101,7 @@ export function useRepDetector(exercise: Exercise) {
       flagCounts: { ...flagCounts.current },
       topFlag: getTopFlag(flagCounts.current),
       score: computeScore(totalReps.current, flagCounts.current),
+      repRecords: [...repRecords.current],
     };
   }, []);
 
@@ -108,6 +114,7 @@ export function useRepDetector(exercise: Exercise) {
     };
     totalReps.current = 0;
     flagCounts.current = {};
+    repRecords.current = [];
   }, []);
 
   return { processPose, getStats, reset };

--- a/src/lib/formInsights.ts
+++ b/src/lib/formInsights.ts
@@ -1,0 +1,56 @@
+import type { RepRecord } from "./types";
+
+/**
+ * Detect form fatigue: whether later reps have significantly more flags than early reps.
+ * Returns a fatigue insight if the last 3 reps have notably more flags than the first 3.
+ */
+export function detectFatigue(
+  repRecords: RepRecord[]
+): { detected: boolean; message: string } {
+  if (repRecords.length < 6) {
+    return { detected: false, message: "" };
+  }
+
+  const first3 = repRecords.slice(0, 3);
+  const last3 = repRecords.slice(-3);
+
+  const first3Flags = first3.filter((r) => r.flag !== null).length;
+  const last3Flags = last3.filter((r) => r.flag !== null).length;
+
+  // Fatigue detected if last 3 reps have at least 2 more flags than first 3
+  if (last3Flags - first3Flags >= 2) {
+    return {
+      detected: true,
+      message:
+        "Your form declined in later reps. Try reducing reps per set or taking longer rest.",
+    };
+  }
+
+  return { detected: false, message: "" };
+}
+
+/**
+ * Find the best and worst rep indices (by flag count — fewer flags = better).
+ * Returns null indices if no meaningful difference exists.
+ */
+export function findBestWorstReps(
+  repRecords: RepRecord[]
+): { bestRep: number | null; worstRep: number | null } {
+  if (repRecords.length === 0) return { bestRep: null, worstRep: null };
+
+  // Best rep = first rep with no flag; worst rep = first rep with a flag
+  let bestRep: number | null = null;
+  let worstRep: number | null = null;
+
+  for (const r of repRecords) {
+    if (r.flag === null && bestRep === null) {
+      bestRep = r.repNumber;
+    }
+    if (r.flag !== null && worstRep === null) {
+      worstRep = r.repNumber;
+    }
+    if (bestRep !== null && worstRep !== null) break;
+  }
+
+  return { bestRep, worstRep };
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -14,6 +14,11 @@ export type FormFlag =
   | "uneven_press"
   | "incomplete_lockout";
 
+export interface RepRecord {
+  repNumber: number;
+  flag: FormFlag | null;
+}
+
 export interface SessionRecord {
   id: string;
   date: string;

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,4 +1,4 @@
-import type { Exercise, FormFlag } from "./lib/types";
+import type { Exercise, FormFlag, RepRecord } from "./lib/types";
 
 export type TrainStackParamList = {
   Home: undefined;
@@ -8,6 +8,7 @@ export type TrainStackParamList = {
     reps: number;
     topFlag: FormFlag | null;
     score: number;
+    repRecords: RepRecord[];
   };
 };
 

--- a/src/screens/Session.tsx
+++ b/src/screens/Session.tsx
@@ -100,6 +100,7 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
       reps: stats.totalReps,
       topFlag: stats.topFlag,
       score: stats.score,
+      repRecords: stats.repRecords,
     });
   }, [navigation, exerciseType, getStats]);
 

--- a/src/screens/Summary.tsx
+++ b/src/screens/Summary.tsx
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   TouchableOpacity,
   SafeAreaView,
+  ScrollView,
 } from "react-native";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { SessionRecord } from "../lib/types";
@@ -14,12 +15,13 @@ import {
   EXERCISE_LABELS,
 } from "../lib/types";
 import { addSession, loadSessions, findPreviousSession } from "../lib/sessionStorage";
+import { detectFatigue, findBestWorstReps } from "../lib/formInsights";
 import type { TrainStackParamList } from "../navigation";
 
 type SummaryProps = NativeStackScreenProps<TrainStackParamList, "Summary">;
 
 export default function SummaryScreen({ route, navigation }: SummaryProps) {
-  const { exercise, reps, topFlag, score } = route.params;
+  const { exercise, reps, topFlag, score, repRecords } = route.params;
   const [delta, setDelta] = useState<number | null>(null);
   const [saved, setSaved] = useState(false);
 
@@ -45,15 +47,16 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
 
   const flagLabel = topFlag ? FLAG_LABELS[topFlag] : null;
   const drill = topFlag ? DRILL_SUGGESTIONS[topFlag] : null;
+  const fatigue = detectFatigue(repRecords);
+  const { bestRep, worstRep } = findBestWorstReps(repRecords);
 
   const handleDone = () => {
-    // Pop all the way back to Home
     navigation.popToTop();
   };
 
   return (
     <SafeAreaView style={styles.container}>
-      <View style={styles.content}>
+      <ScrollView style={styles.scrollContent} contentContainerStyle={styles.scrollContainer}>
         <Text style={styles.title}>Session Complete</Text>
 
         <View style={styles.card}>
@@ -89,6 +92,58 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
           </View>
         </View>
 
+        {/* Rep-by-rep breakdown */}
+        {repRecords.length > 0 && (
+          <View style={styles.breakdownCard}>
+            <Text style={styles.sectionTitle}>Rep Breakdown</Text>
+            {repRecords.map((rep) => {
+              const isBest = rep.repNumber === bestRep;
+              const isWorst = rep.repNumber === worstRep;
+              const hasFlag = rep.flag !== null;
+              const barColor = hasFlag ? "#f59e0b" : "#22c55e";
+
+              return (
+                <View
+                  key={rep.repNumber}
+                  style={[
+                    styles.repRow,
+                    isBest && styles.repRowBest,
+                    isWorst && styles.repRowWorst,
+                  ]}
+                >
+                  <View style={styles.repNumberContainer}>
+                    <Text style={styles.repNumber}>{rep.repNumber}</Text>
+                  </View>
+                  <View style={styles.repBarContainer}>
+                    <View
+                      style={[styles.repBar, { backgroundColor: barColor }]}
+                    />
+                  </View>
+                  <View style={styles.repFlagContainer}>
+                    {hasFlag ? (
+                      <Text style={styles.repFlagText}>
+                        {FLAG_LABELS[rep.flag!]}
+                      </Text>
+                    ) : (
+                      <Text style={styles.repGoodText}>Good</Text>
+                    )}
+                  </View>
+                  {isBest && <Text style={styles.repBadge}>Best</Text>}
+                  {isWorst && <Text style={styles.repBadgeWorst}>Fix</Text>}
+                </View>
+              );
+            })}
+          </View>
+        )}
+
+        {/* Fatigue indicator */}
+        {fatigue.detected && (
+          <View style={styles.fatigueCard}>
+            <Text style={styles.fatigueTitle}>Form Fatigue Detected</Text>
+            <Text style={styles.fatigueText}>{fatigue.message}</Text>
+          </View>
+        )}
+
         <View style={styles.feedbackCard}>
           {flagLabel ? (
             <>
@@ -111,7 +166,7 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
         {saved && (
           <Text style={styles.savedNote}>Session saved to history</Text>
         )}
-      </View>
+      </ScrollView>
 
       <TouchableOpacity style={styles.doneButton} onPress={handleDone}>
         <Text style={styles.doneButtonText}>Done</Text>
@@ -125,10 +180,13 @@ const styles = StyleSheet.create({
     flex: 1,
     backgroundColor: "#0a0a0f",
   },
-  content: {
+  scrollContent: {
     flex: 1,
+  },
+  scrollContainer: {
     paddingHorizontal: 20,
     paddingTop: 40,
+    paddingBottom: 20,
   },
   title: {
     fontSize: 28,
@@ -165,6 +223,105 @@ const styles = StyleSheet.create({
     color: "#ffffff80",
     marginTop: 4,
   },
+  // Rep breakdown
+  breakdownCard: {
+    backgroundColor: "#1a1a24",
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+  },
+  sectionTitle: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ffffff60",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 14,
+  },
+  repRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 8,
+    paddingHorizontal: 8,
+    borderRadius: 8,
+    marginBottom: 4,
+  },
+  repRowBest: {
+    backgroundColor: "#22c55e10",
+  },
+  repRowWorst: {
+    backgroundColor: "#f59e0b10",
+  },
+  repNumberContainer: {
+    width: 28,
+  },
+  repNumber: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#ffffff80",
+  },
+  repBarContainer: {
+    width: 4,
+    height: 20,
+    marginRight: 12,
+  },
+  repBar: {
+    width: 4,
+    height: 20,
+    borderRadius: 2,
+  },
+  repFlagContainer: {
+    flex: 1,
+  },
+  repFlagText: {
+    fontSize: 13,
+    color: "#f59e0b",
+  },
+  repGoodText: {
+    fontSize: 13,
+    color: "#22c55e",
+  },
+  repBadge: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#22c55e",
+    backgroundColor: "#22c55e20",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+    overflow: "hidden",
+  },
+  repBadgeWorst: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#f59e0b",
+    backgroundColor: "#f59e0b20",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 6,
+    overflow: "hidden",
+  },
+  // Fatigue
+  fatigueCard: {
+    backgroundColor: "#ef444420",
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: "#ef444440",
+  },
+  fatigueTitle: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#ef4444",
+    marginBottom: 6,
+  },
+  fatigueText: {
+    fontSize: 14,
+    color: "#ffffffcc",
+    lineHeight: 20,
+  },
+  // Feedback
   feedbackCard: {
     backgroundColor: "#1a1a24",
     borderRadius: 16,


### PR DESCRIPTION
## Summary
- Per-rep data (flag per rep) collected during session and passed to Summary
- Rep breakdown section: color-coded bars (green=good, amber=flagged) with flag labels
- Best/worst rep badges highlighted
- Form fatigue detection: alerts when last 3 reps have significantly more flags than first 3
- Pure `formInsights.ts` module with 8 unit tests

## Test plan
- [ ] Summary screen shows rep-by-rep breakdown after completing a session
- [ ] Each rep shows its number, colored indicator, and flag label (or "Good")
- [ ] Best rep (first clean rep) gets green "Best" badge
- [ ] Worst rep (first flagged rep) gets amber "Fix" badge
- [ ] Fatigue warning appears when late reps degrade vs early reps (need 6+ reps)
- [ ] Fatigue suggestion is actionable ("reduce reps or take longer rest")
- [ ] `npm test` passes (53 tests)
- [ ] `npx tsc --noEmit` clean

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)