### PR TITLE
feat: rest timer and multi-set session flow

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,6 +9,7 @@ import type { TrainStackParamList, TabParamList } from "./src/navigation";
 import HomeScreen from "./src/screens/Home";
 import Session from "./src/screens/Session";
 import SummaryScreen from "./src/screens/Summary";
+import RestTimerScreen from "./src/screens/RestTimer";
 import HistoryScreen from "./src/screens/History";
 import OnboardingScreen, { ONBOARDING_KEY } from "./src/screens/Onboarding";
 import SettingsScreen from "./src/screens/Settings";
@@ -41,6 +42,7 @@ function TrainStack() {
     >
       <Stack.Screen name="Home" component={HomeScreen} />
       <Stack.Screen name="Session" component={Session} />
+      <Stack.Screen name="RestTimer" component={RestTimerScreen} />
       <Stack.Screen name="Summary" component={SummaryScreen} />
     </Stack.Navigator>
   );

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -19,6 +19,14 @@ export interface RepRecord {
   flag: FormFlag | null;
 }
 
+export interface SetRecord {
+  setNumber: number;
+  reps: number;
+  score: number;
+  topFlag: FormFlag | null;
+  repRecords: RepRecord[];
+}
+
 export interface SessionRecord {
   id: string;
   date: string;
@@ -26,6 +34,8 @@ export interface SessionRecord {
   reps: number;
   topFlag: FormFlag | null;
   score: number;
+  sets?: SetRecord[];
+  durationMs?: number;
 }
 
 export const FLAG_LABELS: Record<FormFlag, string> = {

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,14 +1,26 @@
-import type { Exercise, FormFlag, RepRecord } from "./lib/types";
+import type { Exercise, FormFlag, RepRecord, SetRecord } from "./lib/types";
 
 export type TrainStackParamList = {
   Home: undefined;
-  Session: { exerciseType: Exercise };
+  Session: {
+    exerciseType: Exercise;
+    setNumber?: number;
+    previousSets?: SetRecord[];
+    workoutStartTime?: number;
+  };
+  RestTimer: {
+    exerciseType: Exercise;
+    completedSets: SetRecord[];
+    workoutStartTime: number;
+  };
   Summary: {
     exercise: Exercise;
     reps: number;
     topFlag: FormFlag | null;
     score: number;
     repRecords: RepRecord[];
+    sets?: SetRecord[];
+    durationMs?: number;
   };
 };
 

--- a/src/screens/RestTimer.tsx
+++ b/src/screens/RestTimer.tsx
@@ -1,0 +1,315 @@
+import React, { useState, useEffect, useRef, useCallback } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  SafeAreaView,
+} from "react-native";
+import * as Haptics from "expo-haptics";
+import Svg, { Circle } from "react-native-svg";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import type { TrainStackParamList } from "../navigation";
+import { EXERCISE_LABELS } from "../lib/types";
+
+type RestTimerProps = NativeStackScreenProps<TrainStackParamList, "RestTimer">;
+
+const REST_OPTIONS = [60, 90, 120, 180] as const;
+const CIRCLE_SIZE = 200;
+const STROKE_WIDTH = 8;
+const RADIUS = (CIRCLE_SIZE - STROKE_WIDTH) / 2;
+const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
+
+export default function RestTimerScreen({
+  route,
+  navigation,
+}: RestTimerProps) {
+  const { exerciseType, completedSets, workoutStartTime } = route.params;
+  const [restDuration, setRestDuration] = useState(90);
+  const [remaining, setRemaining] = useState(90);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const hasVibrated = useRef(false);
+
+  const startTimer = useCallback(
+    (duration: number) => {
+      if (timerRef.current) clearInterval(timerRef.current);
+      setRemaining(duration);
+      hasVibrated.current = false;
+
+      timerRef.current = setInterval(() => {
+        setRemaining((prev) => {
+          if (prev <= 1) {
+            if (timerRef.current) clearInterval(timerRef.current);
+            if (!hasVibrated.current) {
+              hasVibrated.current = true;
+              void Haptics.notificationAsync(
+                Haptics.NotificationFeedbackType.Success
+              );
+            }
+            return 0;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+    },
+    []
+  );
+
+  useEffect(() => {
+    startTimer(restDuration);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [restDuration, startTimer]);
+
+  const handleSelectDuration = (dur: number) => {
+    setRestDuration(dur);
+  };
+
+  const handleNextSet = () => {
+    if (timerRef.current) clearInterval(timerRef.current);
+    navigation.replace("Session", {
+      exerciseType,
+      setNumber: completedSets.length + 1,
+      previousSets: completedSets,
+      workoutStartTime,
+    });
+  };
+
+  const handleEndWorkout = () => {
+    if (timerRef.current) clearInterval(timerRef.current);
+
+    // Combine all sets into aggregate stats
+    const totalReps = completedSets.reduce((s, set) => s + set.reps, 0);
+    const avgScore =
+      completedSets.length > 0
+        ? Math.round(
+            completedSets.reduce((s, set) => s + set.score, 0) /
+              completedSets.length
+          )
+        : 100;
+    const allRepRecords = completedSets.flatMap((set) => set.repRecords);
+
+    // Find most common flag
+    const flagCounts: Record<string, number> = {};
+    for (const set of completedSets) {
+      if (set.topFlag) {
+        flagCounts[set.topFlag] = (flagCounts[set.topFlag] ?? 0) + 1;
+      }
+    }
+    let topFlag: string | null = null;
+    let maxCount = 0;
+    for (const [flag, count] of Object.entries(flagCounts)) {
+      if (count > maxCount) {
+        maxCount = count;
+        topFlag = flag;
+      }
+    }
+
+    const durationMs = Date.now() - workoutStartTime;
+
+    navigation.replace("Summary", {
+      exercise: exerciseType,
+      reps: totalReps,
+      topFlag: topFlag as typeof completedSets[0]["topFlag"],
+      score: avgScore,
+      repRecords: allRepRecords,
+      sets: completedSets,
+      durationMs,
+    });
+  };
+
+  const progress = restDuration > 0 ? remaining / restDuration : 0;
+  const strokeDashoffset = CIRCUMFERENCE * (1 - progress);
+
+  const minutes = Math.floor(remaining / 60);
+  const seconds = remaining % 60;
+  const timeDisplay = `${minutes}:${seconds.toString().padStart(2, "0")}`;
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.title}>Rest</Text>
+        <Text style={styles.subtitle}>
+          {EXERCISE_LABELS[exerciseType]} — Set {completedSets.length} done
+        </Text>
+      </View>
+
+      <View style={styles.timerContainer}>
+        <Svg width={CIRCLE_SIZE} height={CIRCLE_SIZE}>
+          {/* Background circle */}
+          <Circle
+            cx={CIRCLE_SIZE / 2}
+            cy={CIRCLE_SIZE / 2}
+            r={RADIUS}
+            stroke="#2a2a3a"
+            strokeWidth={STROKE_WIDTH}
+            fill="none"
+          />
+          {/* Progress circle */}
+          <Circle
+            cx={CIRCLE_SIZE / 2}
+            cy={CIRCLE_SIZE / 2}
+            r={RADIUS}
+            stroke={remaining === 0 ? "#22c55e" : "#00E5FF"}
+            strokeWidth={STROKE_WIDTH}
+            fill="none"
+            strokeDasharray={CIRCUMFERENCE}
+            strokeDashoffset={strokeDashoffset}
+            strokeLinecap="round"
+            rotation={-90}
+            origin={`${CIRCLE_SIZE / 2}, ${CIRCLE_SIZE / 2}`}
+          />
+        </Svg>
+        <View style={styles.timerTextContainer}>
+          <Text style={styles.timerText}>{timeDisplay}</Text>
+          {remaining === 0 && (
+            <Text style={styles.readyText}>Ready!</Text>
+          )}
+        </View>
+      </View>
+
+      {/* Duration selector */}
+      <View style={styles.durationRow}>
+        {REST_OPTIONS.map((dur) => (
+          <TouchableOpacity
+            key={dur}
+            style={[
+              styles.durationButton,
+              restDuration === dur && styles.durationButtonActive,
+            ]}
+            onPress={() => handleSelectDuration(dur)}
+          >
+            <Text
+              style={[
+                styles.durationText,
+                restDuration === dur && styles.durationTextActive,
+              ]}
+            >
+              {dur >= 60 ? `${dur / 60}m` : `${dur}s`}
+              {dur === 90 ? "" : ""}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      <View style={styles.actions}>
+        <TouchableOpacity
+          style={styles.nextSetButton}
+          onPress={handleNextSet}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.nextSetText}>
+            {remaining === 0 ? "Start Next Set" : "Skip Rest"}
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={styles.endButton}
+          onPress={handleEndWorkout}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.endText}>End Workout</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0a0a0f",
+  },
+  header: {
+    paddingHorizontal: 20,
+    paddingTop: 40,
+    alignItems: "center",
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: "#ffffff",
+  },
+  subtitle: {
+    fontSize: 15,
+    color: "#ffffff60",
+    marginTop: 6,
+  },
+  timerContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  timerTextContainer: {
+    position: "absolute",
+    alignItems: "center",
+  },
+  timerText: {
+    fontSize: 48,
+    fontWeight: "700",
+    color: "#ffffff",
+    fontVariant: ["tabular-nums"],
+  },
+  readyText: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#22c55e",
+    marginTop: 4,
+  },
+  durationRow: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 12,
+    marginBottom: 32,
+  },
+  durationButton: {
+    paddingHorizontal: 18,
+    paddingVertical: 10,
+    borderRadius: 20,
+    backgroundColor: "#1a1a24",
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+  },
+  durationButtonActive: {
+    borderColor: "#00E5FF",
+    backgroundColor: "#00E5FF15",
+  },
+  durationText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#ffffff60",
+  },
+  durationTextActive: {
+    color: "#00E5FF",
+  },
+  actions: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+    gap: 12,
+  },
+  nextSetButton: {
+    backgroundColor: "#6366f1",
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  nextSetText: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#ffffff",
+  },
+  endButton: {
+    backgroundColor: "#1a1a24",
+    paddingVertical: 14,
+    borderRadius: 12,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+  },
+  endText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#ffffff80",
+  },
+});

--- a/src/screens/Session.tsx
+++ b/src/screens/Session.tsx
@@ -41,10 +41,12 @@ import {
 type SessionProps = NativeStackScreenProps<TrainStackParamList, "Session">;
 
 export default function Session({ route, navigation }: SessionProps): React.ReactElement {
-  const { exerciseType } = route.params;
+  const { exerciseType, setNumber = 0, previousSets = [], workoutStartTime } = route.params;
+  const currentSet = setNumber || (previousSets.length + 1);
+  const sessionStartTime = useRef(workoutStartTime || Date.now());
 
-  // Camera guide shown before first rep
-  const [showGuide, setShowGuide] = useState(true);
+  // Camera guide shown only for first set
+  const [showGuide, setShowGuide] = useState(currentSet === 1);
 
   const { cameraRef, permissionState, requestPermission, openSettings } =
     useCamera();
@@ -92,17 +94,26 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
     }
   }, [poses, processPose, showGuide]);
 
-  const handleEndSession = useCallback(() => {
+  const handleFinishSet = useCallback(() => {
     const stats = getStats();
     trackSessionEnd(exerciseType, stats.totalReps, stats.score);
-    navigation.navigate("Summary", {
-      exercise: exerciseType,
+
+    const thisSet = {
+      setNumber: currentSet,
       reps: stats.totalReps,
-      topFlag: stats.topFlag,
       score: stats.score,
+      topFlag: stats.topFlag,
       repRecords: stats.repRecords,
+    };
+    const allSets = [...previousSets, thisSet];
+
+    // Navigate to rest timer (user can choose to continue or end)
+    navigation.replace("RestTimer", {
+      exerciseType,
+      completedSets: allSets,
+      workoutStartTime: sessionStartTime.current,
     });
-  }, [navigation, exerciseType, getStats]);
+  }, [navigation, exerciseType, getStats, currentSet, previousSets]);
 
   const handleGuideReady = useCallback(() => {
     setShowGuide(false);
@@ -194,9 +205,11 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
         />
       )}
 
-      {/* Exercise name + rep counter header */}
+      {/* Exercise name + set/rep counter header */}
       <View style={styles.exerciseHeader} pointerEvents="none">
-        <Text style={styles.exerciseName}>{EXERCISE_LABELS[exerciseType]}</Text>
+        <Text style={styles.exerciseName}>
+          {EXERCISE_LABELS[exerciseType]} — Set {currentSet}
+        </Text>
         <Text style={styles.repCounter}>{repCount} reps</Text>
       </View>
 
@@ -225,12 +238,12 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
       <View style={styles.endSessionContainer}>
         <TouchableOpacity
           style={styles.endSessionButton}
-          onPress={handleEndSession}
+          onPress={handleFinishSet}
           activeOpacity={0.7}
           accessibilityRole="button"
           accessibilityLabel="End session"
         >
-          <Text style={styles.endSessionText}>End Session</Text>
+          <Text style={styles.endSessionText}>Finish Set</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/src/screens/Summary.tsx
+++ b/src/screens/Summary.tsx
@@ -20,8 +20,16 @@ import type { TrainStackParamList } from "../navigation";
 
 type SummaryProps = NativeStackScreenProps<TrainStackParamList, "Summary">;
 
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  if (minutes === 0) return `${seconds}s`;
+  return `${minutes}m ${seconds}s`;
+}
+
 export default function SummaryScreen({ route, navigation }: SummaryProps) {
-  const { exercise, reps, topFlag, score, repRecords } = route.params;
+  const { exercise, reps, topFlag, score, repRecords, sets, durationMs } = route.params;
   const [delta, setDelta] = useState<number | null>(null);
   const [saved, setSaved] = useState(false);
 
@@ -33,6 +41,8 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
       reps,
       topFlag,
       score,
+      sets,
+      durationMs,
     };
 
     addSession(session).then(async () => {
@@ -43,7 +53,7 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
         setDelta(reps - prev.reps);
       }
     });
-  }, [exercise, reps, topFlag, score]);
+  }, [exercise, reps, topFlag, score, sets, durationMs]);
 
   const flagLabel = topFlag ? FLAG_LABELS[topFlag] : null;
   const drill = topFlag ? DRILL_SUGGESTIONS[topFlag] : null;
@@ -57,7 +67,9 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView style={styles.scrollContent} contentContainerStyle={styles.scrollContainer}>
-        <Text style={styles.title}>Session Complete</Text>
+        <Text style={styles.title}>
+          {sets && sets.length > 1 ? "Workout Complete" : "Session Complete"}
+        </Text>
 
         <View style={styles.card}>
           <Text style={styles.exerciseName}>
@@ -65,15 +77,31 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
           </Text>
 
           <View style={styles.statsRow}>
+            {sets && sets.length > 1 && (
+              <View style={styles.stat}>
+                <Text style={styles.statValue}>{sets.length}</Text>
+                <Text style={styles.statLabel}>Sets</Text>
+              </View>
+            )}
+
             <View style={styles.stat}>
               <Text style={styles.statValue}>{reps}</Text>
-              <Text style={styles.statLabel}>Reps</Text>
+              <Text style={styles.statLabel}>Total Reps</Text>
             </View>
 
             <View style={styles.stat}>
               <Text style={styles.statValue}>{score}%</Text>
-              <Text style={styles.statLabel}>Form Score</Text>
+              <Text style={styles.statLabel}>
+                {sets && sets.length > 1 ? "Avg Score" : "Form Score"}
+              </Text>
             </View>
+
+            {durationMs != null && (
+              <View style={styles.stat}>
+                <Text style={styles.statValue}>{formatDuration(durationMs)}</Text>
+                <Text style={styles.statLabel}>Duration</Text>
+              </View>
+            )}
 
             {delta !== null && (
               <View style={styles.stat}>
@@ -91,6 +119,25 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
             )}
           </View>
         </View>
+
+        {/* Per-set breakdown */}
+        {sets && sets.length > 1 && (
+          <View style={styles.breakdownCard}>
+            <Text style={styles.sectionTitle}>Sets</Text>
+            {sets.map((set) => (
+              <View key={set.setNumber} style={styles.setRow}>
+                <Text style={styles.setNumber}>Set {set.setNumber}</Text>
+                <Text style={styles.setReps}>{set.reps} reps</Text>
+                <Text style={styles.setScore}>{set.score}%</Text>
+                {set.topFlag && (
+                  <Text style={styles.setFlag}>
+                    {FLAG_LABELS[set.topFlag]}
+                  </Text>
+                )}
+              </View>
+            ))}
+          </View>
+        )}
 
         {/* Rep-by-rep breakdown */}
         {repRecords.length > 0 && (
@@ -208,13 +255,14 @@ const styles = StyleSheet.create({
   },
   statsRow: {
     flexDirection: "row",
-    gap: 24,
+    flexWrap: "wrap",
+    gap: 20,
   },
   stat: {
     alignItems: "center",
   },
   statValue: {
-    fontSize: 32,
+    fontSize: 28,
     fontWeight: "700",
     color: "#ffffff",
   },
@@ -365,6 +413,38 @@ const styles = StyleSheet.create({
     color: "#ffffff40",
     textAlign: "center",
     marginTop: 8,
+  },
+  // Set rows
+  setRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 10,
+    paddingHorizontal: 8,
+    borderRadius: 8,
+    marginBottom: 4,
+    gap: 12,
+  },
+  setNumber: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#ffffff80",
+    width: 48,
+  },
+  setReps: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#ffffffcc",
+  },
+  setScore: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#6366f1",
+  },
+  setFlag: {
+    fontSize: 12,
+    color: "#f59e0b",
+    flex: 1,
+    textAlign: "right",
   },
   doneButton: {
     backgroundColor: "#6366f1",


### PR DESCRIPTION
## Summary
- New `RestTimer` screen with circular countdown (60/90/120/180s), haptic on completion
- Multi-set flow: Session → RestTimer → Session → ... → Summary
- Session screen shows set number and "Finish Set" button
- Summary shows per-set breakdown for multi-set workouts, total duration
- `SetRecord` type and backward-compatible `SessionRecord` extension

## Test plan
- [ ] After finishing a set, rest timer appears with 90s countdown
- [ ] Duration selector changes timer (60/90/120/180s)
- [ ] "Skip Rest" returns to Session for next set
- [ ] "End Workout" goes to Summary with all sets combined
- [ ] Haptic fires when timer reaches 0
- [ ] Session screen shows "Set 1", "Set 2", etc.
- [ ] Summary shows per-set breakdown when multi-set
- [ ] Summary shows duration for the full workout
- [ ] Single-set sessions still work normally
- [ ] Old sessions in History render correctly (no `sets` field)
- [ ] Camera guide only shows for first set
- [ ] `npm test` passes (53 tests)
- [ ] `npx tsc --noEmit` clean

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)