### PR TITLE
feat: in-app feedback form for beta testers

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -18,6 +18,12 @@ jest.mock("expo-haptics", () => ({
   },
 }));
 
+// Mock expo-mail-composer
+jest.mock("expo-mail-composer", () => ({
+  isAvailableAsync: jest.fn(() => Promise.resolve(true)),
+  composeAsync: jest.fn(() => Promise.resolve({ status: "sent" })),
+}));
+
 // Mock @react-native-async-storage/async-storage
 jest.mock("@react-native-async-storage/async-storage", () =>
   require("@react-native-async-storage/async-storage/jest/async-storage-mock")

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "expo-device": "^55.0.12",
         "expo-gl": "^55.0.10",
         "expo-haptics": "^55.0.11",
+        "expo-mail-composer": "~15.0.8",
         "expo-speech": "~14.0.8",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
@@ -9343,6 +9344,15 @@
       "version": "55.0.11",
       "resolved": "https://registry.npmjs.org/expo-haptics/-/expo-haptics-55.0.11.tgz",
       "integrity": "sha512-cvayByobLtoS5Yt2JFqcBPH+1mnLHkz+Rr+H1EOCZDdTVo5T6aaAHMOZrbRBZBhxrUevAPxfz0bfyhVZj3XHzA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-mail-composer": {
+      "version": "15.0.8",
+      "resolved": "https://registry.npmjs.org/expo-mail-composer/-/expo-mail-composer-15.0.8.tgz",
+      "integrity": "sha512-v9oGZ+523ByMXxH6C82V96otbIbQEFTyk1AhBX02nFTlUpg+qlGCV5fycMGDRxfsWmRGRVfX+0K3zwpIz1NmuQ==",
       "license": "MIT",
       "peerDependencies": {
         "expo": "*"

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "expo-device": "^55.0.12",
     "expo-gl": "^55.0.10",
     "expo-haptics": "^55.0.11",
+    "expo-mail-composer": "~15.0.8",
     "expo-speech": "~14.0.8",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",

--- a/src/__tests__/feedbackUtils.test.ts
+++ b/src/__tests__/feedbackUtils.test.ts
@@ -1,0 +1,51 @@
+import { validateMessage, buildEmailSubject, buildEmailBody } from "../lib/feedbackUtils";
+
+describe("validateMessage", () => {
+  it("returns error for empty message", () => {
+    expect(validateMessage("")).toBe("Message is required");
+  });
+
+  it("returns error for whitespace-only message", () => {
+    expect(validateMessage("   ")).toBe("Message is required");
+  });
+
+  it("returns error for message under 10 chars", () => {
+    expect(validateMessage("too short")).toBe("Please write at least 10 characters");
+  });
+
+  it("returns null for valid message", () => {
+    expect(validateMessage("This is a valid feedback message")).toBeNull();
+  });
+
+  it("returns null for exactly 10 chars", () => {
+    expect(validateMessage("1234567890")).toBeNull();
+  });
+});
+
+describe("buildEmailSubject", () => {
+  it("includes category label", () => {
+    expect(buildEmailSubject("bug")).toContain("Bug Report");
+  });
+
+  it("includes app name", () => {
+    expect(buildEmailSubject("feature")).toContain("Gym Form Coach");
+  });
+});
+
+describe("buildEmailBody", () => {
+  it("includes the message", () => {
+    const body = buildEmailBody("My feedback", "general", false);
+    expect(body).toContain("My feedback");
+  });
+
+  it("includes device info when enabled", () => {
+    const body = buildEmailBody("My feedback", "bug", true);
+    expect(body).toContain("Device:");
+    expect(body).toContain("Category: Bug Report");
+  });
+
+  it("excludes device info when disabled", () => {
+    const body = buildEmailBody("My feedback", "bug", false);
+    expect(body).not.toContain("Device:");
+  });
+});

--- a/src/lib/feedbackUtils.ts
+++ b/src/lib/feedbackUtils.ts
@@ -1,0 +1,51 @@
+import Constants from "expo-constants";
+import * as Device from "expo-device";
+import { Platform } from "react-native";
+
+export type FeedbackCategory = "bug" | "feature" | "general";
+
+export const CATEGORY_LABELS: Record<FeedbackCategory, string> = {
+  bug: "Bug Report",
+  feature: "Feature Request",
+  general: "General Feedback",
+};
+
+const APP_VERSION = Constants.expoConfig?.version ?? "unknown";
+const BUILD_NUMBER =
+  Platform.OS === "ios"
+    ? Constants.expoConfig?.ios?.buildNumber ?? "—"
+    : String(Constants.expoConfig?.android?.versionCode ?? "—");
+
+export function getDeviceInfoString(): string {
+  const model = Device.modelName ?? "Unknown device";
+  const os = `${Device.osName ?? Platform.OS} ${Device.osVersion ?? ""}`.trim();
+  return `${model} (${os})`;
+}
+
+export function buildEmailSubject(category: FeedbackCategory): string {
+  return `[Gym Form Coach v${APP_VERSION}] ${CATEGORY_LABELS[category]}`;
+}
+
+export function buildEmailBody(
+  message: string,
+  category: FeedbackCategory,
+  includeDeviceInfo: boolean
+): string {
+  const lines: string[] = [message, ""];
+
+  if (includeDeviceInfo) {
+    lines.push("---");
+    lines.push(`App: Gym Form Coach v${APP_VERSION} (build ${BUILD_NUMBER})`);
+    lines.push(`Device: ${getDeviceInfoString()}`);
+    lines.push(`Category: ${CATEGORY_LABELS[category]}`);
+  }
+
+  return lines.join("\n");
+}
+
+export function validateMessage(message: string): string | null {
+  const trimmed = message.trim();
+  if (trimmed.length === 0) return "Message is required";
+  if (trimmed.length < 10) return "Please write at least 10 characters";
+  return null;
+}

--- a/src/screens/Feedback.tsx
+++ b/src/screens/Feedback.tsx
@@ -1,0 +1,236 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  SafeAreaView,
+  Alert,
+  Switch,
+  ScrollView,
+} from "react-native";
+import * as MailComposer from "expo-mail-composer";
+import type { FeedbackCategory } from "../lib/feedbackUtils";
+import {
+  CATEGORY_LABELS,
+  buildEmailSubject,
+  buildEmailBody,
+  validateMessage,
+} from "../lib/feedbackUtils";
+
+const CATEGORIES: FeedbackCategory[] = ["bug", "feature", "general"];
+const FEEDBACK_EMAIL = "feedback@gymformcoach.app";
+
+interface FeedbackScreenProps {
+  onClose: () => void;
+}
+
+export default function FeedbackScreen({ onClose }: FeedbackScreenProps) {
+  const [category, setCategory] = useState<FeedbackCategory>("general");
+  const [message, setMessage] = useState("");
+  const [includeDeviceInfo, setIncludeDeviceInfo] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    const validationError = validateMessage(message);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    setError(null);
+
+    const isAvailable = await MailComposer.isAvailableAsync();
+    if (!isAvailable) {
+      Alert.alert(
+        "Email Not Available",
+        "No email client is configured on this device. Please email your feedback to " +
+          FEEDBACK_EMAIL
+      );
+      return;
+    }
+
+    await MailComposer.composeAsync({
+      recipients: [FEEDBACK_EMAIL],
+      subject: buildEmailSubject(category),
+      body: buildEmailBody(message, category, includeDeviceInfo),
+    });
+
+    onClose();
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <View style={styles.header}>
+          <Text style={styles.title}>Send Feedback</Text>
+          <TouchableOpacity onPress={onClose}>
+            <Text style={styles.cancelText}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+
+        {/* Category picker */}
+        <Text style={styles.label}>Category</Text>
+        <View style={styles.categoryRow}>
+          {CATEGORIES.map((cat) => (
+            <TouchableOpacity
+              key={cat}
+              style={[
+                styles.categoryButton,
+                category === cat && styles.categoryButtonActive,
+              ]}
+              onPress={() => setCategory(cat)}
+            >
+              <Text
+                style={[
+                  styles.categoryText,
+                  category === cat && styles.categoryTextActive,
+                ]}
+              >
+                {CATEGORY_LABELS[cat]}
+              </Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+
+        {/* Message */}
+        <Text style={styles.label}>Message</Text>
+        <TextInput
+          style={styles.textInput}
+          multiline
+          numberOfLines={6}
+          placeholder="Describe your feedback..."
+          placeholderTextColor="#ffffff30"
+          value={message}
+          onChangeText={(text) => {
+            setMessage(text);
+            if (error) setError(null);
+          }}
+          textAlignVertical="top"
+        />
+        {error && <Text style={styles.errorText}>{error}</Text>}
+
+        {/* Device info toggle */}
+        <View style={styles.toggleRow}>
+          <Text style={styles.toggleLabel}>Include device info</Text>
+          <Switch
+            value={includeDeviceInfo}
+            onValueChange={setIncludeDeviceInfo}
+            trackColor={{ false: "#2a2a3a", true: "#00E5FF40" }}
+            thumbColor={includeDeviceInfo ? "#00E5FF" : "#ffffff50"}
+          />
+        </View>
+
+        <TouchableOpacity
+          style={styles.submitButton}
+          onPress={handleSubmit}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.submitText}>Open Email</Text>
+        </TouchableOpacity>
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0a0a0f",
+  },
+  content: {
+    padding: 20,
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: "#ffffff",
+  },
+  cancelText: {
+    fontSize: 15,
+    color: "#00E5FF",
+    fontWeight: "600",
+  },
+  label: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ffffff60",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 10,
+  },
+  categoryRow: {
+    flexDirection: "row",
+    gap: 10,
+    marginBottom: 24,
+  },
+  categoryButton: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 10,
+    backgroundColor: "#1a1a24",
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+    alignItems: "center",
+  },
+  categoryButtonActive: {
+    borderColor: "#00E5FF",
+    backgroundColor: "#00E5FF15",
+  },
+  categoryText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ffffff60",
+  },
+  categoryTextActive: {
+    color: "#00E5FF",
+  },
+  textInput: {
+    backgroundColor: "#1a1a24",
+    borderRadius: 12,
+    padding: 16,
+    fontSize: 15,
+    color: "#ffffff",
+    minHeight: 140,
+    marginBottom: 8,
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+  },
+  errorText: {
+    fontSize: 13,
+    color: "#ef4444",
+    marginBottom: 8,
+  },
+  toggleRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    backgroundColor: "#1a1a24",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderRadius: 10,
+    marginTop: 16,
+    marginBottom: 24,
+  },
+  toggleLabel: {
+    fontSize: 15,
+    color: "#ffffffcc",
+  },
+  submitButton: {
+    backgroundColor: "#6366f1",
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: "center",
+  },
+  submitText: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#ffffff",
+  },
+});

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   View,
   Text,
@@ -11,6 +11,7 @@ import {
 import * as Clipboard from "expo-clipboard";
 import Constants from "expo-constants";
 import * as Device from "expo-device";
+import FeedbackScreen from "./Feedback";
 
 const APP_NAME = Constants.expoConfig?.name ?? "Gym Form Coach";
 const APP_VERSION = Constants.expoConfig?.version ?? "unknown";
@@ -43,11 +44,17 @@ function buildFeedbackTemplate(): string {
 }
 
 export default function SettingsScreen() {
+  const [showFeedback, setShowFeedback] = useState(false);
+
   const handleCopyFeedback = async () => {
     const template = buildFeedbackTemplate();
     await Clipboard.setStringAsync(template);
     Alert.alert("Copied", "Bug report template copied to clipboard.");
   };
+
+  if (showFeedback) {
+    return <FeedbackScreen onClose={() => setShowFeedback(false)} />;
+  }
 
   return (
     <SafeAreaView style={styles.container}>
@@ -84,10 +91,23 @@ export default function SettingsScreen() {
 
         <TouchableOpacity
           style={styles.feedbackButton}
+          onPress={() => setShowFeedback(true)}
+          activeOpacity={0.7}
+        >
+          <Text style={styles.feedbackButtonText}>Send Feedback</Text>
+          <Text style={styles.feedbackHint}>
+            Report bugs, request features, or share thoughts
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[styles.feedbackButton, { marginTop: 8 }]}
           onPress={handleCopyFeedback}
           activeOpacity={0.7}
         >
-          <Text style={styles.feedbackButtonText}>Copy Bug Report Template</Text>
+          <Text style={[styles.feedbackButtonText, { color: "#ffffff80" }]}>
+            Copy Bug Report Template
+          </Text>
           <Text style={styles.feedbackHint}>
             Paste into email or message to report issues
           </Text>


### PR DESCRIPTION
## Summary
- New `Feedback` screen with category picker, message textarea, device info toggle
- Opens native email via `expo-mail-composer` with pre-filled subject/body
- Form validation with inline errors (min 10 chars)
- "Send Feedback" button on Settings screen
- 10 unit tests for validation and email building

## Test plan
- [ ] "Send Feedback" button visible on Settings screen
- [ ] Tapping opens feedback form with category picker and message area
- [ ] Category buttons toggle correctly (Bug/Feature/General)
- [ ] Submit with empty message shows "Message is required" error
- [ ] Submit with <10 chars shows length error
- [ ] Valid submit opens email composer with correct subject and body
- [ ] Device info included when toggle is on, excluded when off
- [ ] Cancel returns to Settings
- [ ] `npm test` passes (63 tests)
- [ ] `npx tsc --noEmit` clean

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)