### PR TITLE
feat: error handling and edge case states

### DIFF
--- a/src/components/ErrorState.tsx
+++ b/src/components/ErrorState.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { View, Text, StyleSheet, TouchableOpacity } from "react-native";
+
+interface ErrorStateProps {
+  title: string;
+  message: string;
+  actionLabel?: string;
+  onAction?: () => void;
+}
+
+export default function ErrorState({
+  title,
+  message,
+  actionLabel,
+  onAction,
+}: ErrorStateProps) {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{title}</Text>
+      <Text style={styles.message}>{message}</Text>
+      {actionLabel && onAction && (
+        <TouchableOpacity style={styles.button} onPress={onAction}>
+          <Text style={styles.buttonText}>{actionLabel}</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 40,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#ffffff",
+    marginBottom: 8,
+    textAlign: "center",
+  },
+  message: {
+    fontSize: 14,
+    color: "#ffffff60",
+    textAlign: "center",
+    lineHeight: 20,
+    marginBottom: 24,
+  },
+  button: {
+    backgroundColor: "#6366f1",
+    paddingVertical: 12,
+    paddingHorizontal: 28,
+    borderRadius: 10,
+  },
+  buttonText: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#ffffff",
+  },
+});

--- a/src/components/LoadingState.tsx
+++ b/src/components/LoadingState.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
+
+interface LoadingStateProps {
+  message?: string;
+}
+
+export default function LoadingState({
+  message = "Loading...",
+}: LoadingStateProps) {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator size="large" color="#00E5FF" />
+      <Text style={styles.message}>{message}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 40,
+  },
+  message: {
+    fontSize: 14,
+    color: "#ffffff60",
+    marginTop: 16,
+    textAlign: "center",
+  },
+});

--- a/src/screens/Session.tsx
+++ b/src/screens/Session.tsx
@@ -79,11 +79,18 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
     enabled: permissionState === "granted" && !showGuide,
   });
 
+  // Track no-landmarks hint
+  const [showNoLandmarksHint, setShowNoLandmarksHint] = useState(false);
+  const lastPoseTime = useRef(0);
+  const noLandmarksTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   // Process each pose frame through the form analyser
   const prevPosesRef = useRef(poses);
   useEffect(() => {
     if (poses === prevPosesRef.current || poses.length === 0 || showGuide) return;
     prevPosesRef.current = poses;
+    lastPoseTime.current = Date.now();
+    setShowNoLandmarksHint(false);
 
     const pose = poses[0];
     const event = processPose(pose);
@@ -93,6 +100,21 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
       setLastCueRep(event.repNumber);
     }
   }, [poses, processPose, showGuide]);
+
+  // Show hint if no poses detected for 5+ seconds after model is ready
+  useEffect(() => {
+    if (!modelReady || showGuide) return;
+    noLandmarksTimer.current = setInterval(() => {
+      if (lastPoseTime.current > 0 && Date.now() - lastPoseTime.current > 5000) {
+        setShowNoLandmarksHint(true);
+      } else if (lastPoseTime.current === 0 && Date.now() - (lastPoseTime.current || Date.now()) > 5000) {
+        setShowNoLandmarksHint(true);
+      }
+    }, 1000);
+    return () => {
+      if (noLandmarksTimer.current) clearInterval(noLandmarksTimer.current);
+    };
+  }, [modelReady, showGuide]);
 
   const handleFinishSet = useCallback(() => {
     const stats = getStats();
@@ -231,6 +253,15 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
         </View>
       )}
 
+      {/* No landmarks hint */}
+      {showNoLandmarksHint && modelReady && (
+        <View style={styles.hintBadge} pointerEvents="none">
+          <Text style={styles.hintText}>
+            Make sure your full body is visible in the camera
+          </Text>
+        </View>
+      )}
+
       {/* Safety banner — always visible during session */}
       <SafetyBanner />
 
@@ -345,6 +376,24 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: "600",
     fontVariant: ["tabular-nums"],
+  },
+  // Hint
+  hintBadge: {
+    position: "absolute",
+    bottom: Platform.OS === "ios" ? 140 : 120,
+    left: 20,
+    right: 20,
+    backgroundColor: "rgba(245,158,11,0.9)",
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 10,
+    alignItems: "center",
+  },
+  hintText: {
+    color: "#000",
+    fontSize: 14,
+    fontWeight: "600",
+    textAlign: "center",
   },
   // End Session
   endSessionContainer: {

--- a/src/screens/Summary.tsx
+++ b/src/screens/Summary.tsx
@@ -71,6 +71,16 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
           {sets && sets.length > 1 ? "Workout Complete" : "Session Complete"}
         </Text>
 
+        {reps === 0 && (
+          <View style={styles.zeroRepCard}>
+            <Text style={styles.zeroRepTitle}>No Reps Detected</Text>
+            <Text style={styles.zeroRepMessage}>
+              Check your camera placement and make sure your full body is
+              visible. Try placing your phone further away.
+            </Text>
+          </View>
+        )}
+
         <View style={styles.card}>
           <Text style={styles.exerciseName}>
             {EXERCISE_LABELS[exercise]}
@@ -413,6 +423,26 @@ const styles = StyleSheet.create({
     color: "#ffffff40",
     textAlign: "center",
     marginTop: 8,
+  },
+  // Zero rep warning
+  zeroRepCard: {
+    backgroundColor: "#f59e0b20",
+    borderRadius: 16,
+    padding: 20,
+    marginBottom: 16,
+    borderWidth: 1,
+    borderColor: "#f59e0b40",
+  },
+  zeroRepTitle: {
+    fontSize: 17,
+    fontWeight: "700",
+    color: "#f59e0b",
+    marginBottom: 8,
+  },
+  zeroRepMessage: {
+    fontSize: 14,
+    color: "#ffffffcc",
+    lineHeight: 20,
   },
   // Set rows
   setRow: {


### PR DESCRIPTION
## Summary
- Shared `ErrorState` and `LoadingState` reusable components
- No-landmarks hint overlay after 5s of no pose detection
- Zero-rep warning on Summary screen with camera placement advice
- Hint auto-dismisses when poses resume

## Test plan
- [ ] Session: after 5s with no body visible, amber hint appears
- [ ] Session: hint disappears when body becomes visible again
- [ ] Summary: zero-rep session shows warning card with advice
- [ ] Existing error states still work (camera denied, model loading)
- [ ] `npm test` passes (63 tests)
- [ ] `npx tsc --noEmit` clean

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)