### PR TITLE
feat: per-exercise preferences (rest, sets, reps)

### DIFF
--- a/src/__tests__/preferences.test.ts
+++ b/src/__tests__/preferences.test.ts
@@ -1,0 +1,59 @@
+import {
+  loadAllPreferences,
+  loadPreferences,
+  savePreferences,
+} from "../lib/sessionStorage";
+import { DEFAULT_PREFERENCES } from "../lib/types";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+beforeEach(async () => {
+  await AsyncStorage.clear();
+});
+
+describe("exercise preferences", () => {
+  it("returns defaults when no preferences are saved", async () => {
+    const prefs = await loadPreferences("squat");
+    expect(prefs).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("saves and loads preferences for an exercise", async () => {
+    await savePreferences("squat", {
+      restTimeSeconds: 120,
+      targetSets: 5,
+      targetReps: 10,
+    });
+
+    const prefs = await loadPreferences("squat");
+    expect(prefs.restTimeSeconds).toBe(120);
+    expect(prefs.targetSets).toBe(5);
+    expect(prefs.targetReps).toBe(10);
+  });
+
+  it("keeps preferences separate per exercise", async () => {
+    await savePreferences("squat", {
+      restTimeSeconds: 120,
+      targetSets: 5,
+      targetReps: 10,
+    });
+    await savePreferences("deadlift", {
+      restTimeSeconds: 180,
+      targetSets: 3,
+      targetReps: 5,
+    });
+
+    const squat = await loadPreferences("squat");
+    const deadlift = await loadPreferences("deadlift");
+    const pushup = await loadPreferences("pushup");
+
+    expect(squat.restTimeSeconds).toBe(120);
+    expect(deadlift.restTimeSeconds).toBe(180);
+    expect(pushup).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it("loadAllPreferences returns all saved preferences", async () => {
+    await savePreferences("squat", { ...DEFAULT_PREFERENCES, targetReps: 12 });
+    const all = await loadAllPreferences();
+    expect(all.squat?.targetReps).toBe(12);
+    expect(all.deadlift).toBeUndefined();
+  });
+});

--- a/src/lib/sessionStorage.ts
+++ b/src/lib/sessionStorage.ts
@@ -1,7 +1,9 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import type { Exercise, SessionRecord } from "./types";
+import type { Exercise, ExercisePreferences, SessionRecord } from "./types";
+import { DEFAULT_PREFERENCES } from "./types";
 
 const STORAGE_KEY = "@gym_form_coach/sessions";
+const PREFS_KEY = "@gym_form_coach/exercise_preferences";
 const MAX_SESSIONS = 50;
 
 export async function saveSessions(
@@ -135,4 +137,34 @@ export function getScoreTrend(
   if (session.score > prev.score) return 1;
   if (session.score < prev.score) return -1;
   return 0;
+}
+
+// ── Exercise Preferences ──────────────────────────────────────────────────
+
+export async function loadAllPreferences(): Promise<
+  Partial<Record<Exercise, ExercisePreferences>>
+> {
+  const raw = await AsyncStorage.getItem(PREFS_KEY);
+  if (!raw) return {};
+  try {
+    return JSON.parse(raw) as Partial<Record<Exercise, ExercisePreferences>>;
+  } catch {
+    return {};
+  }
+}
+
+export async function loadPreferences(
+  exercise: Exercise
+): Promise<ExercisePreferences> {
+  const all = await loadAllPreferences();
+  return all[exercise] ?? { ...DEFAULT_PREFERENCES };
+}
+
+export async function savePreferences(
+  exercise: Exercise,
+  prefs: ExercisePreferences
+): Promise<void> {
+  const all = await loadAllPreferences();
+  all[exercise] = prefs;
+  await AsyncStorage.setItem(PREFS_KEY, JSON.stringify(all));
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,18 @@ export interface SessionRecord {
   durationMs?: number;
 }
 
+export interface ExercisePreferences {
+  restTimeSeconds: 60 | 90 | 120 | 180;
+  targetSets: number;
+  targetReps: number;
+}
+
+export const DEFAULT_PREFERENCES: ExercisePreferences = {
+  restTimeSeconds: 90,
+  targetSets: 3,
+  targetReps: 8,
+};
+
 export const FLAG_LABELS: Record<FormFlag, string> = {
   knees_caving: "Knees caving in",
   depth_too_shallow: "Depth too shallow",

--- a/src/screens/RestTimer.tsx
+++ b/src/screens/RestTimer.tsx
@@ -11,6 +11,7 @@ import Svg, { Circle } from "react-native-svg";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { TrainStackParamList } from "../navigation";
 import { EXERCISE_LABELS } from "../lib/types";
+import { loadPreferences } from "../lib/sessionStorage";
 
 type RestTimerProps = NativeStackScreenProps<TrainStackParamList, "RestTimer">;
 
@@ -29,6 +30,17 @@ export default function RestTimerScreen({
   const [remaining, setRemaining] = useState(90);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const hasVibrated = useRef(false);
+  const prefsLoaded = useRef(false);
+
+  // Load saved default rest time
+  useEffect(() => {
+    if (prefsLoaded.current) return;
+    prefsLoaded.current = true;
+    loadPreferences(exerciseType).then((prefs) => {
+      setRestDuration(prefs.restTimeSeconds);
+      setRemaining(prefs.restTimeSeconds);
+    });
+  }, [exerciseType]);
 
   const startTimer = useCallback(
     (duration: number) => {

--- a/src/screens/Session.tsx
+++ b/src/screens/Session.tsx
@@ -30,8 +30,9 @@ import PoseOverlay from "../components/PoseOverlay";
 import CueBanner from "../components/CueBanner";
 import SafetyBanner from "../components/SafetyBanner";
 import CameraGuide from "../components/CameraGuide";
-import { EXERCISE_LABELS } from "../lib/types";
-import type { FormFlag } from "../lib/types";
+import { EXERCISE_LABELS, DEFAULT_PREFERENCES } from "../lib/types";
+import type { ExercisePreferences, FormFlag } from "../lib/types";
+import { loadPreferences } from "../lib/sessionStorage";
 import type { TrainStackParamList } from "../navigation";
 import {
   trackSessionStart,
@@ -53,6 +54,12 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
 
   const [isCameraReady, setIsCameraReady] = useState(false);
   const [overlaySize, setOverlaySize] = useState({ width: 0, height: 0 });
+
+  // Exercise preferences
+  const [prefs, setPrefs] = useState<ExercisePreferences>({ ...DEFAULT_PREFERENCES });
+  useEffect(() => {
+    loadPreferences(exerciseType).then(setPrefs);
+  }, [exerciseType]);
 
   // Rep detection + form analysis
   const { processPose, getStats, reset } = useRepDetector(exerciseType);
@@ -231,8 +238,11 @@ export default function Session({ route, navigation }: SessionProps): React.Reac
       <View style={styles.exerciseHeader} pointerEvents="none">
         <Text style={styles.exerciseName}>
           {EXERCISE_LABELS[exerciseType]} — Set {currentSet}
+          {prefs.targetSets > 0 ? ` of ${prefs.targetSets}` : ""}
         </Text>
-        <Text style={styles.repCounter}>{repCount} reps</Text>
+        <Text style={styles.repCounter}>
+          {repCount}{prefs.targetReps > 0 ? ` / ${prefs.targetReps}` : ""} reps
+        </Text>
       </View>
 
       {/* Audio + visual cue banner */}

--- a/src/screens/Settings.tsx
+++ b/src/screens/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
   View,
   Text,
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   Alert,
   Platform,
+  ScrollView,
 } from "react-native";
 import * as Clipboard from "expo-clipboard";
 import * as Sharing from "expo-sharing";
@@ -14,7 +15,9 @@ import { cacheDirectory, writeAsStringAsync } from "expo-file-system/build/legac
 import Constants from "expo-constants";
 import * as Device from "expo-device";
 import FeedbackScreen from "./Feedback";
-import { loadSessions } from "../lib/sessionStorage";
+import { loadSessions, loadAllPreferences, savePreferences } from "../lib/sessionStorage";
+import type { Exercise, ExercisePreferences } from "../lib/types";
+import { EXERCISE_LABELS, DEFAULT_PREFERENCES } from "../lib/types";
 import {
   sessionsToCSV,
   sessionsToJSON,
@@ -52,8 +55,29 @@ function buildFeedbackTemplate(): string {
   ].join("\n");
 }
 
+const REST_OPTIONS = [60, 90, 120, 180] as const;
+const SET_OPTIONS = [1, 2, 3, 4, 5, 6, 8, 10];
+const REP_OPTIONS = [3, 5, 6, 8, 10, 12, 15, 20];
+const EXERCISES: Exercise[] = ["squat", "deadlift", "pushup", "overheadPress"];
+
 export default function SettingsScreen() {
   const [showFeedback, setShowFeedback] = useState(false);
+  const [allPrefs, setAllPrefs] = useState<Partial<Record<Exercise, ExercisePreferences>>>({});
+  const [expandedExercise, setExpandedExercise] = useState<Exercise | null>(null);
+
+  useEffect(() => {
+    loadAllPreferences().then(setAllPrefs);
+  }, []);
+
+  const updatePref = useCallback(
+    async (exercise: Exercise, update: Partial<ExercisePreferences>) => {
+      const current = allPrefs[exercise] ?? { ...DEFAULT_PREFERENCES };
+      const updated = { ...current, ...update };
+      await savePreferences(exercise, updated);
+      setAllPrefs((prev) => ({ ...prev, [exercise]: updated }));
+    },
+    [allPrefs]
+  );
 
   const handleExport = async (format: ExportFormat) => {
     const sessions = await loadSessions();
@@ -87,8 +111,79 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
+      <ScrollView showsVerticalScrollIndicator={false}>
       <View style={styles.header}>
         <Text style={styles.title}>Settings</Text>
+      </View>
+
+      {/* Exercise Preferences */}
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>Exercise Preferences</Text>
+        {EXERCISES.map((ex) => {
+          const prefs = allPrefs[ex] ?? DEFAULT_PREFERENCES;
+          const isExpanded = expandedExercise === ex;
+          return (
+            <View key={ex}>
+              <TouchableOpacity
+                style={styles.prefHeader}
+                onPress={() => setExpandedExercise(isExpanded ? null : ex)}
+              >
+                <Text style={styles.prefExercise}>{EXERCISE_LABELS[ex]}</Text>
+                <Text style={styles.prefSummary}>
+                  {prefs.targetSets}x{prefs.targetReps} • {prefs.restTimeSeconds}s rest
+                </Text>
+              </TouchableOpacity>
+              {isExpanded && (
+                <View style={styles.prefDetails}>
+                  <Text style={styles.prefLabel}>Rest Time</Text>
+                  <View style={styles.optionRow}>
+                    {REST_OPTIONS.map((t) => (
+                      <TouchableOpacity
+                        key={t}
+                        style={[styles.optionPill, prefs.restTimeSeconds === t && styles.optionPillActive]}
+                        onPress={() => updatePref(ex, { restTimeSeconds: t })}
+                      >
+                        <Text style={[styles.optionText, prefs.restTimeSeconds === t && styles.optionTextActive]}>
+                          {t}s
+                        </Text>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+
+                  <Text style={styles.prefLabel}>Target Sets</Text>
+                  <View style={styles.optionRow}>
+                    {SET_OPTIONS.map((s) => (
+                      <TouchableOpacity
+                        key={s}
+                        style={[styles.optionPill, prefs.targetSets === s && styles.optionPillActive]}
+                        onPress={() => updatePref(ex, { targetSets: s })}
+                      >
+                        <Text style={[styles.optionText, prefs.targetSets === s && styles.optionTextActive]}>
+                          {s}
+                        </Text>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+
+                  <Text style={styles.prefLabel}>Target Reps</Text>
+                  <View style={styles.optionRow}>
+                    {REP_OPTIONS.map((r) => (
+                      <TouchableOpacity
+                        key={r}
+                        style={[styles.optionPill, prefs.targetReps === r && styles.optionPillActive]}
+                        onPress={() => updatePref(ex, { targetReps: r })}
+                      >
+                        <Text style={[styles.optionText, prefs.targetReps === r && styles.optionTextActive]}>
+                          {r}
+                        </Text>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+                </View>
+              )}
+            </View>
+          );
+        })}
       </View>
 
       <View style={styles.section}>
@@ -166,6 +261,7 @@ export default function SettingsScreen() {
           </Text>
         </TouchableOpacity>
       </View>
+      </ScrollView>
     </SafeAreaView>
   );
 }
@@ -215,6 +311,67 @@ const styles = StyleSheet.create({
     fontSize: 15,
     color: "#ffffff",
     fontWeight: "500",
+  },
+  // Exercise Preferences
+  prefHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    backgroundColor: "#1a1a24",
+    paddingHorizontal: 16,
+    paddingVertical: 14,
+    borderRadius: 10,
+    marginBottom: 6,
+  },
+  prefExercise: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#ffffff",
+  },
+  prefSummary: {
+    fontSize: 13,
+    color: "#ffffff50",
+  },
+  prefDetails: {
+    backgroundColor: "#1a1a24",
+    borderRadius: 10,
+    padding: 16,
+    marginBottom: 6,
+    marginTop: -2,
+  },
+  prefLabel: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#ffffff50",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginBottom: 8,
+    marginTop: 12,
+  },
+  optionRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  optionPill: {
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 16,
+    backgroundColor: "#0a0a0f",
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+  },
+  optionPillActive: {
+    borderColor: "#00E5FF",
+    backgroundColor: "#00E5FF15",
+  },
+  optionText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ffffff50",
+  },
+  optionTextActive: {
+    color: "#00E5FF",
   },
   exportRow: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- Per-exercise preferences: default rest time, target sets, target reps
- Expandable config cards in Settings with pill selectors
- Session shows "Set X of Y" and rep targets
- RestTimer pre-selects saved default
- Persisted in AsyncStorage, 4 unit tests

## Test plan
- [ ] Settings shows Exercise Preferences section with 4 exercises
- [ ] Tapping an exercise expands to show rest/sets/reps pickers
- [ ] Selecting a value persists across app restart
- [ ] Session screen shows set count "of Y" and rep target
- [ ] Rest timer starts with saved default duration
- [ ] Defaults used when no preference is set
- [ ] `npm test` passes (84 tests)
- [ ] `npx tsc --noEmit` clean

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)