### PR TITLE
feat: weekly form report with score trends

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,6 +11,7 @@ import Session from "./src/screens/Session";
 import SummaryScreen from "./src/screens/Summary";
 import RestTimerScreen from "./src/screens/RestTimer";
 import ExerciseTipsScreen from "./src/screens/ExerciseTips";
+import WeeklyReportScreen from "./src/screens/WeeklyReport";
 import HistoryScreen from "./src/screens/History";
 import OnboardingScreen, { ONBOARDING_KEY } from "./src/screens/Onboarding";
 import SettingsScreen from "./src/screens/Settings";
@@ -42,6 +43,7 @@ function TrainStack() {
       }}
     >
       <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen name="WeeklyReport" component={WeeklyReportScreen} />
       <Stack.Screen name="ExerciseTips" component={ExerciseTipsScreen} />
       <Stack.Screen name="Session" component={Session} />
       <Stack.Screen name="RestTimer" component={RestTimerScreen} />

--- a/src/__tests__/weeklyReport.test.ts
+++ b/src/__tests__/weeklyReport.test.ts
@@ -1,0 +1,76 @@
+import type { SessionRecord } from "../lib/types";
+import { computeWeeklyReport } from "../lib/weeklyReportHelpers";
+
+function makeSession(
+  daysAgo: number,
+  overrides: Partial<SessionRecord> = {}
+): SessionRecord {
+  const d = new Date();
+  d.setDate(d.getDate() - daysAgo);
+  return {
+    id: `session-${daysAgo}-${Math.random()}`,
+    date: d.toISOString(),
+    exercise: "squat",
+    reps: 8,
+    topFlag: null,
+    score: 80,
+    ...overrides,
+  };
+}
+
+describe("computeWeeklyReport", () => {
+  it("returns zero for empty sessions", () => {
+    const report = computeWeeklyReport([]);
+    expect(report.sessionCount).toBe(0);
+    expect(report.avgScore).toBe(0);
+    expect(report.exercises).toEqual([]);
+  });
+
+  it("counts sessions from the past 7 days only", () => {
+    const sessions = [
+      makeSession(1), // this week
+      makeSession(3), // this week
+      makeSession(10), // too old
+    ];
+    const report = computeWeeklyReport(sessions);
+    expect(report.sessionCount).toBe(2);
+  });
+
+  it("computes average score correctly", () => {
+    const sessions = [
+      makeSession(1, { score: 90 }),
+      makeSession(2, { score: 70 }),
+    ];
+    const report = computeWeeklyReport(sessions);
+    expect(report.avgScore).toBe(80);
+  });
+
+  it("identifies top flag", () => {
+    const sessions = [
+      makeSession(1, { topFlag: "knees_caving" }),
+      makeSession(2, { topFlag: "knees_caving" }),
+      makeSession(3, { topFlag: "forward_lean" }),
+    ];
+    const report = computeWeeklyReport(sessions);
+    expect(report.topFlag?.flag).toBe("knees_caving");
+    expect(report.topFlag?.drill).toBeTruthy();
+  });
+
+  it("computes week-over-week comparison", () => {
+    const sessions = [
+      makeSession(1, { score: 90 }), // this week
+      makeSession(10, { score: 70 }), // last week
+    ];
+    const report = computeWeeklyReport(sessions);
+    expect(report.avgScore).toBe(90);
+    expect(report.prevWeekAvgScore).toBe(70);
+  });
+
+  it("generates daily scores for 7 days", () => {
+    const report = computeWeeklyReport([makeSession(1, { score: 85 })]);
+    expect(report.dailyScores).toHaveLength(7);
+    // At least one day should have a non-zero score
+    const nonZero = report.dailyScores.filter((d) => d.avgScore > 0);
+    expect(nonZero.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/lib/weeklyReportHelpers.ts
+++ b/src/lib/weeklyReportHelpers.ts
@@ -1,0 +1,135 @@
+import type { Exercise, FormFlag, SessionRecord } from "./types";
+import { DRILL_SUGGESTIONS, FLAG_LABELS } from "./types";
+
+export interface WeeklyReportData {
+  sessionCount: number;
+  exercises: Exercise[];
+  avgScore: number;
+  prevWeekAvgScore: number | null;
+  topFlag: { flag: FormFlag; label: string; drill: string } | null;
+  newPersonalBests: { exercise: Exercise; score: number }[];
+  dailyScores: { day: string; avgScore: number }[];
+}
+
+function startOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function daysAgo(n: number): Date {
+  const d = startOfDay(new Date());
+  d.setDate(d.getDate() - n);
+  return d;
+}
+
+function isInRange(dateStr: string, start: Date, end: Date): boolean {
+  const d = new Date(dateStr);
+  return d >= start && d < end;
+}
+
+/**
+ * Compute weekly report data from session history.
+ */
+export function computeWeeklyReport(
+  sessions: SessionRecord[],
+  allSessions?: SessionRecord[]
+): WeeklyReportData {
+  const now = new Date();
+  const weekStart = daysAgo(7);
+  const prevWeekStart = daysAgo(14);
+  const weekEnd = startOfDay(now);
+  weekEnd.setDate(weekEnd.getDate() + 1); // include today
+
+  // This week's sessions
+  const thisWeek = sessions.filter((s) => isInRange(s.date, weekStart, weekEnd));
+  const prevWeek = sessions.filter((s) =>
+    isInRange(s.date, prevWeekStart, weekStart)
+  );
+
+  // Session count and exercises
+  const exercises = [...new Set(thisWeek.map((s) => s.exercise))];
+
+  // Average score
+  const avgScore =
+    thisWeek.length > 0
+      ? Math.round(
+          thisWeek.reduce((sum, s) => sum + s.score, 0) / thisWeek.length
+        )
+      : 0;
+
+  const prevWeekAvgScore =
+    prevWeek.length > 0
+      ? Math.round(
+          prevWeek.reduce((sum, s) => sum + s.score, 0) / prevWeek.length
+        )
+      : null;
+
+  // Top flag
+  const flagCounts: Partial<Record<FormFlag, number>> = {};
+  for (const s of thisWeek) {
+    if (s.topFlag) {
+      flagCounts[s.topFlag] = (flagCounts[s.topFlag] ?? 0) + 1;
+    }
+  }
+  let topFlag: WeeklyReportData["topFlag"] = null;
+  let maxFlagCount = 0;
+  for (const [flag, count] of Object.entries(flagCounts)) {
+    if (count! > maxFlagCount) {
+      maxFlagCount = count!;
+      const f = flag as FormFlag;
+      topFlag = {
+        flag: f,
+        label: FLAG_LABELS[f],
+        drill: DRILL_SUGGESTIONS[f],
+      };
+    }
+  }
+
+  // New personal bests — check if any session this week has the highest score for its exercise
+  const all = allSessions ?? sessions;
+  const newPersonalBests: WeeklyReportData["newPersonalBests"] = [];
+  for (const ex of exercises) {
+    const bestThisWeek = Math.max(
+      ...thisWeek.filter((s) => s.exercise === ex).map((s) => s.score)
+    );
+    const bestAllTime = Math.max(
+      ...all.filter((s) => s.exercise === ex).map((s) => s.score)
+    );
+    if (bestThisWeek >= bestAllTime && bestThisWeek > 0) {
+      newPersonalBests.push({ exercise: ex, score: bestThisWeek });
+    }
+  }
+
+  // Daily scores for past 7 days
+  const dailyScores: WeeklyReportData["dailyScores"] = [];
+  for (let i = 6; i >= 0; i--) {
+    const dayStart = daysAgo(i);
+    const dayEnd = new Date(dayStart);
+    dayEnd.setDate(dayEnd.getDate() + 1);
+
+    const daySessions = thisWeek.filter((s) =>
+      isInRange(s.date, dayStart, dayEnd)
+    );
+    const dayLabel = dayStart.toLocaleDateString(undefined, { weekday: "short" });
+
+    if (daySessions.length > 0) {
+      const avg = Math.round(
+        daySessions.reduce((sum, s) => sum + s.score, 0) / daySessions.length
+      );
+      dailyScores.push({ day: dayLabel, avgScore: avg });
+    } else {
+      dailyScores.push({ day: dayLabel, avgScore: 0 });
+    }
+  }
+
+  return {
+    sessionCount: thisWeek.length,
+    exercises,
+    avgScore,
+    prevWeekAvgScore,
+    topFlag,
+    newPersonalBests,
+    dailyScores,
+  };
+}

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -2,6 +2,7 @@ import type { Exercise, FormFlag, RepRecord, SetRecord } from "./lib/types";
 
 export type TrainStackParamList = {
   Home: undefined;
+  WeeklyReport: undefined;
   ExerciseTips: { exerciseType: Exercise };
   Session: {
     exerciseType: Exercise;

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -29,7 +29,15 @@ export default function HomeScreen({ navigation }: HomeProps) {
   return (
     <SafeAreaView style={styles.container}>
       <View style={styles.header}>
-        <Text style={styles.title}>Gym Form Coach</Text>
+        <View style={styles.headerTop}>
+          <Text style={styles.title}>Gym Form Coach</Text>
+          <TouchableOpacity
+            style={styles.reportButton}
+            onPress={() => navigation.navigate("WeeklyReport")}
+          >
+            <Text style={styles.reportButtonText}>Weekly Report</Text>
+          </TouchableOpacity>
+        </View>
         <Text style={styles.subtitle}>Choose an exercise to start</Text>
       </View>
 
@@ -76,6 +84,24 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     paddingTop: 40,
     paddingBottom: 24,
+  },
+  headerTop: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  reportButton: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 8,
+    backgroundColor: "#6366f120",
+    borderWidth: 1,
+    borderColor: "#6366f140",
+  },
+  reportButtonText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#6366f1",
   },
   title: {
     fontSize: 32,

--- a/src/screens/WeeklyReport.tsx
+++ b/src/screens/WeeklyReport.tsx
@@ -1,0 +1,327 @@
+import React, { useEffect, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  SafeAreaView,
+  TouchableOpacity,
+} from "react-native";
+import type { NativeStackScreenProps } from "@react-navigation/native-stack";
+import type { TrainStackParamList } from "../navigation";
+import { EXERCISE_LABELS } from "../lib/types";
+import { loadSessions } from "../lib/sessionStorage";
+import {
+  computeWeeklyReport,
+  type WeeklyReportData,
+} from "../lib/weeklyReportHelpers";
+
+type WeeklyReportProps = NativeStackScreenProps<
+  TrainStackParamList,
+  "WeeklyReport"
+>;
+
+export default function WeeklyReportScreen({
+  navigation,
+}: WeeklyReportProps) {
+  const [report, setReport] = useState<WeeklyReportData | null>(null);
+
+  useEffect(() => {
+    loadSessions().then((sessions) => {
+      setReport(computeWeeklyReport(sessions, sessions));
+    });
+  }, []);
+
+  if (!report) return null;
+
+  if (report.sessionCount === 0) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.header}>
+          <TouchableOpacity onPress={() => navigation.goBack()}>
+            <Text style={styles.backText}>Back</Text>
+          </TouchableOpacity>
+          <Text style={styles.title}>Weekly Report</Text>
+          <View style={{ width: 40 }} />
+        </View>
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyTitle}>No Sessions This Week</Text>
+          <Text style={styles.emptySubtitle}>
+            Complete a workout to see your weekly progress here
+          </Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  const scoreDiff =
+    report.prevWeekAvgScore != null
+      ? report.avgScore - report.prevWeekAvgScore
+      : null;
+  const maxDailyScore = Math.max(...report.dailyScores.map((d) => d.avgScore), 1);
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.header}>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Text style={styles.backText}>Back</Text>
+        </TouchableOpacity>
+        <Text style={styles.title}>Weekly Report</Text>
+        <View style={{ width: 40 }} />
+      </View>
+
+      <ScrollView
+        contentContainerStyle={styles.content}
+        showsVerticalScrollIndicator={false}
+      >
+        {/* Overview stats */}
+        <View style={styles.statsRow}>
+          <View style={styles.statBox}>
+            <Text style={styles.statValue}>{report.sessionCount}</Text>
+            <Text style={styles.statLabel}>Sessions</Text>
+          </View>
+          <View style={styles.statBox}>
+            <Text style={styles.statValue}>{report.avgScore}%</Text>
+            <Text style={styles.statLabel}>Avg Score</Text>
+          </View>
+          {scoreDiff !== null && (
+            <View style={styles.statBox}>
+              <Text
+                style={[
+                  styles.statValue,
+                  { color: scoreDiff >= 0 ? "#22c55e" : "#ef4444" },
+                ]}
+              >
+                {scoreDiff >= 0 ? "+" : ""}
+                {scoreDiff}
+              </Text>
+              <Text style={styles.statLabel}>vs Last Week</Text>
+            </View>
+          )}
+        </View>
+
+        {/* Exercises trained */}
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Exercises</Text>
+          <Text style={styles.exerciseList}>
+            {report.exercises.map((e) => EXERCISE_LABELS[e]).join(", ")}
+          </Text>
+        </View>
+
+        {/* Score trend */}
+        <View style={styles.card}>
+          <Text style={styles.sectionTitle}>Daily Scores</Text>
+          <View style={styles.chartRow}>
+            {report.dailyScores.map((d) => (
+              <View key={d.day} style={styles.chartCol}>
+                <View style={styles.barContainer}>
+                  <View
+                    style={[
+                      styles.bar,
+                      {
+                        height: d.avgScore > 0
+                          ? Math.max(4, (d.avgScore / maxDailyScore) * 80)
+                          : 2,
+                        backgroundColor:
+                          d.avgScore >= 80
+                            ? "#22c55e"
+                            : d.avgScore >= 60
+                              ? "#f59e0b"
+                              : d.avgScore > 0
+                                ? "#ef4444"
+                                : "#2a2a3a",
+                      },
+                    ]}
+                  />
+                </View>
+                <Text style={styles.chartLabel}>{d.day}</Text>
+                {d.avgScore > 0 && (
+                  <Text style={styles.chartValue}>{d.avgScore}</Text>
+                )}
+              </View>
+            ))}
+          </View>
+        </View>
+
+        {/* Top flag to fix */}
+        {report.topFlag && (
+          <View style={styles.flagCard}>
+            <Text style={styles.sectionTitle}>Focus Area</Text>
+            <Text style={styles.flagName}>{report.topFlag.label}</Text>
+            <Text style={styles.flagDrill}>{report.topFlag.drill}</Text>
+          </View>
+        )}
+
+        {/* New personal bests */}
+        {report.newPersonalBests.length > 0 && (
+          <View style={styles.card}>
+            <Text style={styles.sectionTitle}>New Personal Bests</Text>
+            {report.newPersonalBests.map((pb) => (
+              <View key={pb.exercise} style={styles.pbRow}>
+                <Text style={styles.pbExercise}>
+                  {EXERCISE_LABELS[pb.exercise]}
+                </Text>
+                <Text style={styles.pbScore}>{pb.score}%</Text>
+              </View>
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#0a0a0f",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingHorizontal: 20,
+    paddingTop: 16,
+    paddingBottom: 12,
+  },
+  backText: {
+    fontSize: 15,
+    color: "#00E5FF",
+    fontWeight: "600",
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: "700",
+    color: "#ffffff",
+  },
+  content: {
+    paddingHorizontal: 20,
+    paddingBottom: 40,
+  },
+  emptyState: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 40,
+  },
+  emptyTitle: {
+    fontSize: 18,
+    fontWeight: "600",
+    color: "#ffffff",
+    marginBottom: 8,
+  },
+  emptySubtitle: {
+    fontSize: 14,
+    color: "#ffffff50",
+    textAlign: "center",
+  },
+  statsRow: {
+    flexDirection: "row",
+    gap: 10,
+    marginBottom: 16,
+  },
+  statBox: {
+    flex: 1,
+    backgroundColor: "#1a1a24",
+    borderRadius: 12,
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  statValue: {
+    fontSize: 24,
+    fontWeight: "700",
+    color: "#ffffff",
+  },
+  statLabel: {
+    fontSize: 11,
+    color: "#ffffff50",
+    marginTop: 4,
+  },
+  card: {
+    backgroundColor: "#1a1a24",
+    borderRadius: 14,
+    padding: 20,
+    marginBottom: 14,
+  },
+  sectionTitle: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#ffffff50",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 10,
+  },
+  exerciseList: {
+    fontSize: 16,
+    color: "#ffffffcc",
+  },
+  // Chart
+  chartRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+    height: 120,
+  },
+  chartCol: {
+    flex: 1,
+    alignItems: "center",
+  },
+  barContainer: {
+    flex: 1,
+    justifyContent: "flex-end",
+    width: "100%",
+    alignItems: "center",
+  },
+  bar: {
+    width: 20,
+    borderRadius: 4,
+    minHeight: 2,
+  },
+  chartLabel: {
+    fontSize: 10,
+    color: "#ffffff40",
+    marginTop: 6,
+  },
+  chartValue: {
+    fontSize: 10,
+    color: "#ffffff60",
+    marginTop: 2,
+    fontVariant: ["tabular-nums"],
+  },
+  // Flag
+  flagCard: {
+    backgroundColor: "#1a1a24",
+    borderRadius: 14,
+    padding: 20,
+    marginBottom: 14,
+    borderLeftWidth: 3,
+    borderLeftColor: "#f59e0b",
+  },
+  flagName: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#f59e0b",
+    marginBottom: 8,
+  },
+  flagDrill: {
+    fontSize: 14,
+    color: "#ffffffcc",
+    lineHeight: 20,
+  },
+  // Personal bests
+  pbRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 6,
+  },
+  pbExercise: {
+    fontSize: 15,
+    color: "#ffffffcc",
+  },
+  pbScore: {
+    fontSize: 15,
+    fontWeight: "700",
+    color: "#22c55e",
+  },
+});


### PR DESCRIPTION
## Summary
- New Weekly Report screen: session count, avg score, week-over-week comparison
- Daily score bar chart (7 days), top flag to fix, new personal bests
- Accessible from "Weekly Report" button on Home screen
- Pure helper functions with 6 unit tests, 90 total passing

## Test plan
- [ ] Weekly Report button visible on Home screen
- [ ] Report shows session count and average score for past 7 days
- [ ] Week-over-week comparison arrow shown when previous week data exists
- [ ] Daily score bars rendered with correct colors
- [ ] Top flag shown with drill suggestion
- [ ] New personal bests displayed when applicable
- [ ] Empty state shown for zero sessions
- [ ] `npm test` passes (90 tests)

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)