### PR TITLE
feat: improved onboarding with camera permission and exercise picker

### DIFF
--- a/src/screens/Onboarding.tsx
+++ b/src/screens/Onboarding.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useRef, useState, useCallback } from "react";
 import {
   View,
   Text,
@@ -8,8 +8,12 @@ import {
   Dimensions,
   SafeAreaView,
   Platform,
+  TouchableOpacity,
 } from "react-native";
+import { Camera } from "expo-camera";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import type { Exercise } from "../lib/types";
+import { EXERCISE_LABELS } from "../lib/types";
 
 export const ONBOARDING_KEY = "hasCompletedOnboarding";
 
@@ -18,64 +22,228 @@ const { width: SCREEN_WIDTH } = Dimensions.get("window");
 type OnboardingSlide = {
   title: string;
   body: string;
-  accent: string;
+  icon: string;
 };
 
 const SLIDES: OnboardingSlide[] = [
   {
     title: "Real-time form coaching",
     body: "Gym Form Coach uses your phone camera and on-device AI to analyse your exercise form as you move — no trainer, no cloud, no waiting.",
-    accent: "#00E5FF",
+    icon: "🏋️",
+  },
+  {
+    title: "See it in action",
+    body: "The app detects your body position, scores each rep 0-100, and gives you audio cues to fix your form in real time. Track your progress with personal bests and weekly reports.",
+    icon: "📊",
   },
   {
     title: "Set up your phone",
-    body: "Prop your phone at waist height, 6–8 feet away, so your full body is visible in the frame. A yoga block or water bottle works great.",
-    accent: "#00E5FF",
+    body: "Prop your phone at waist height, 6-8 feet away, so your full body is visible in the frame. A yoga block or water bottle works great.",
+    icon: "📱",
   },
   {
     title: "Your privacy is protected",
     body: "All processing happens on your device. No video is ever uploaded, stored externally, or shared with anyone.",
-    accent: "#00E5FF",
+    icon: "🔒",
   },
 ];
 
+const EXERCISES: { type: Exercise; emoji: string }[] = [
+  { type: "squat", emoji: "🏋️" },
+  { type: "deadlift", emoji: "💪" },
+  { type: "pushup", emoji: "🫸" },
+  { type: "overheadPress", emoji: "🙌" },
+];
+
+type OnboardingPhase = "slides" | "camera" | "exercise" | "ready";
+
 type Props = {
-  onComplete: () => void;
+  onComplete: (firstExercise?: Exercise) => void;
 };
 
 export default function OnboardingScreen({ onComplete }: Props) {
   const scrollRef = useRef<ScrollView>(null);
   const [activeIndex, setActiveIndex] = useState(0);
+  const [phase, setPhase] = useState<OnboardingPhase>("slides");
+  const [selectedExercise, setSelectedExercise] = useState<Exercise>("squat");
 
-  async function finish() {
-    await AsyncStorage.setItem(ONBOARDING_KEY, "true");
-    onComplete();
-  }
+  const finish = useCallback(
+    async (exercise?: Exercise) => {
+      await AsyncStorage.setItem(ONBOARDING_KEY, "true");
+      onComplete(exercise);
+    },
+    [onComplete]
+  );
 
   function handleNext() {
     if (activeIndex < SLIDES.length - 1) {
       const nextIndex = activeIndex + 1;
-      scrollRef.current?.scrollTo({ x: nextIndex * SCREEN_WIDTH, animated: true });
+      scrollRef.current?.scrollTo({
+        x: nextIndex * SCREEN_WIDTH,
+        animated: true,
+      });
       setActiveIndex(nextIndex);
     } else {
-      finish();
+      setPhase("camera");
     }
   }
 
-  function handleScroll(event: { nativeEvent: { contentOffset: { x: number } } }) {
+  function handleScroll(event: {
+    nativeEvent: { contentOffset: { x: number } };
+  }) {
     const index = Math.round(event.nativeEvent.contentOffset.x / SCREEN_WIDTH);
     setActiveIndex(index);
   }
 
-  const isLast = activeIndex === SLIDES.length - 1;
+  const handleCameraPermission = useCallback(async () => {
+    await Camera.requestCameraPermissionsAsync();
+    setPhase("exercise");
+  }, []);
 
+  const handleSkipCamera = useCallback(() => {
+    setPhase("exercise");
+  }, []);
+
+  const isLastSlide = activeIndex === SLIDES.length - 1;
+
+  // Camera permission phase
+  if (phase === "camera") {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.topBar}>
+          <Pressable onPress={() => finish()} style={styles.skipButton}>
+            <Text style={styles.skipText}>Skip</Text>
+          </Pressable>
+        </View>
+        <View style={styles.centerContent}>
+          <View style={styles.iconContainer}>
+            <Text style={styles.slideIcon}>📸</Text>
+          </View>
+          <Text style={styles.slideTitle}>Enable Camera</Text>
+          <Text style={styles.slideBody}>
+            The app needs camera access to watch your form. Your video is never
+            recorded or uploaded.
+          </Text>
+        </View>
+        <View style={styles.bottomBar}>
+          <Pressable
+            onPress={handleCameraPermission}
+            style={({ pressed }) => [
+              styles.nextButton,
+              pressed && styles.nextButtonPressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Allow camera access"
+          >
+            <Text style={styles.nextButtonText}>Allow Camera</Text>
+          </Pressable>
+          <TouchableOpacity
+            onPress={handleSkipCamera}
+            style={styles.skipLater}
+          >
+            <Text style={styles.skipLaterText}>I'll do this later</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // Exercise selection phase
+  if (phase === "exercise") {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.topBar}>
+          <Pressable onPress={() => finish()} style={styles.skipButton}>
+            <Text style={styles.skipText}>Skip</Text>
+          </Pressable>
+        </View>
+        <View style={styles.centerContent}>
+          <Text style={styles.slideTitle}>What do you want to try first?</Text>
+          <Text style={[styles.slideBody, { marginBottom: 30 }]}>
+            Pick an exercise to start with. You can try all 4 anytime.
+          </Text>
+          <View style={styles.exerciseGrid}>
+            {EXERCISES.map(({ type, emoji }) => (
+              <TouchableOpacity
+                key={type}
+                style={[
+                  styles.exerciseOption,
+                  selectedExercise === type && styles.exerciseOptionActive,
+                ]}
+                onPress={() => setSelectedExercise(type)}
+                accessibilityRole="button"
+                accessibilityLabel={EXERCISE_LABELS[type]}
+              >
+                <Text style={styles.exerciseEmoji}>{emoji}</Text>
+                <Text
+                  style={[
+                    styles.exerciseLabel,
+                    selectedExercise === type && styles.exerciseLabelActive,
+                  ]}
+                >
+                  {EXERCISE_LABELS[type]}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+        <View style={styles.bottomBar}>
+          <Pressable
+            onPress={() => setPhase("ready")}
+            style={({ pressed }) => [
+              styles.nextButton,
+              pressed && styles.nextButtonPressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel="Continue"
+          >
+            <Text style={styles.nextButtonText}>Continue</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // Ready phase
+  if (phase === "ready") {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.centerContent}>
+          <View style={styles.iconContainer}>
+            <Text style={styles.slideIcon}>✅</Text>
+          </View>
+          <Text style={styles.slideTitle}>You're all set!</Text>
+          <Text style={styles.slideBody}>
+            Prop up your phone, hit start, and get real feedback on every rep.
+          </Text>
+        </View>
+        <View style={styles.bottomBar}>
+          <Pressable
+            onPress={() => finish(selectedExercise)}
+            style={({ pressed }) => [
+              styles.nextButton,
+              pressed && styles.nextButtonPressed,
+            ]}
+            accessibilityRole="button"
+            accessibilityLabel={`Start first workout with ${EXERCISE_LABELS[selectedExercise]}`}
+          >
+            <Text style={styles.nextButtonText}>Start First Workout</Text>
+          </Pressable>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // Slides phase
   return (
     <SafeAreaView style={styles.container}>
-      {/* Skip button */}
       <View style={styles.topBar}>
         <Pressable
-          onPress={finish}
-          style={({ pressed }) => [styles.skipButton, pressed && styles.skipButtonPressed]}
+          onPress={() => finish()}
+          style={({ pressed }) => [
+            styles.skipButton,
+            pressed && styles.skipButtonPressed,
+          ]}
           accessibilityRole="button"
           accessibilityLabel="Skip onboarding"
         >
@@ -83,7 +251,6 @@ export default function OnboardingScreen({ onComplete }: Props) {
         </Pressable>
       </View>
 
-      {/* Slides */}
       <ScrollView
         ref={scrollRef}
         horizontal
@@ -92,12 +259,11 @@ export default function OnboardingScreen({ onComplete }: Props) {
         onMomentumScrollEnd={handleScroll}
         scrollEventThrottle={16}
         style={styles.scrollView}
-        contentContainerStyle={styles.scrollContent}
       >
         {SLIDES.map((slide, index) => (
           <View key={index} style={[styles.slide, { width: SCREEN_WIDTH }]}>
             <View style={styles.iconContainer}>
-              <Text style={styles.slideIcon}>{index === 0 ? "🏋️" : index === 1 ? "📱" : "🔒"}</Text>
+              <Text style={styles.slideIcon}>{slide.icon}</Text>
             </View>
             <Text style={styles.slideTitle}>{slide.title}</Text>
             <Text style={styles.slideBody}>{slide.body}</Text>
@@ -105,7 +271,6 @@ export default function OnboardingScreen({ onComplete }: Props) {
         ))}
       </ScrollView>
 
-      {/* Dots */}
       <View style={styles.dotsRow}>
         {SLIDES.map((_, i) => (
           <View
@@ -118,7 +283,6 @@ export default function OnboardingScreen({ onComplete }: Props) {
         ))}
       </View>
 
-      {/* Next / Get Started button */}
       <View style={styles.bottomBar}>
         <Pressable
           onPress={handleNext}
@@ -127,10 +291,10 @@ export default function OnboardingScreen({ onComplete }: Props) {
             pressed && styles.nextButtonPressed,
           ]}
           accessibilityRole="button"
-          accessibilityLabel={isLast ? "Get started" : "Next slide"}
+          accessibilityLabel={isLastSlide ? "Continue to setup" : "Next slide"}
         >
           <Text style={styles.nextButtonText}>
-            {isLast ? "Get Started" : "Next"}
+            {isLastSlide ? "Continue" : "Next"}
           </Text>
         </Pressable>
       </View>
@@ -166,15 +330,18 @@ const styles = StyleSheet.create({
   scrollView: {
     flex: 1,
   },
-  scrollContent: {
-    // width set per slide
-  },
   slide: {
     flex: 1,
     alignItems: "center",
     justifyContent: "center",
     paddingHorizontal: 36,
     paddingBottom: 20,
+  },
+  centerContent: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 36,
   },
   iconContainer: {
     width: 100,
@@ -242,5 +409,46 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: "700",
     letterSpacing: 0.3,
+  },
+  skipLater: {
+    alignItems: "center",
+    paddingVertical: 12,
+  },
+  skipLaterText: {
+    color: "#ffffff40",
+    fontSize: 14,
+  },
+  // Exercise selection
+  exerciseGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    justifyContent: "center",
+    gap: 12,
+  },
+  exerciseOption: {
+    width: 140,
+    paddingVertical: 16,
+    paddingHorizontal: 12,
+    borderRadius: 14,
+    backgroundColor: "#1a1a24",
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+    alignItems: "center",
+  },
+  exerciseOptionActive: {
+    borderColor: "#00E5FF",
+    backgroundColor: "#00E5FF15",
+  },
+  exerciseEmoji: {
+    fontSize: 32,
+    marginBottom: 8,
+  },
+  exerciseLabel: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#ffffff80",
+  },
+  exerciseLabelActive: {
+    color: "#00E5FF",
   },
 });


### PR DESCRIPTION
## Summary
- 4 onboarding slides (added value prop slide)
- Camera permission request during onboarding
- Exercise selection step
- "You're all set!" ready screen with CTA
- Skip available at every phase

## Test plan
- [ ] 4 slides render with swipe navigation
- [ ] Camera permission dialog triggered during onboarding
- [ ] "I'll do this later" skips camera step
- [ ] Exercise picker shows all 4 exercises
- [ ] "Start First Workout" completes onboarding
- [ ] Skip works from any phase
- [ ] `npm test` passes (95 tests)

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)