### PR TITLE
feat: shareable session summary card — export as image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,8 @@
         "react-native-fs": "^2.20.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
-        "react-native-svg": "^15.15.4"
+        "react-native-svg": "^15.15.4",
+        "react-native-view-shot": "4.0.3"
       },
       "devDependencies": {
         "@testing-library/react-native": "^13.3.3",
@@ -7264,6 +7265,15 @@
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
       "integrity": "sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA=="
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7928,6 +7938,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css-select": {
@@ -10620,6 +10639,19 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -18565,6 +18597,19 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-view-shot": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/react-native-view-shot/-/react-native-view-shot-4.0.3.tgz",
+      "integrity": "sha512-USNjYmED7C0me02c1DxKA0074Hw+y/nxo+xJKlffMvfUWWzL5ELh/TJA/pTnVqFurIrzthZDPtDM7aBFJuhrHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "html2canvas": "^1.4.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/react-native/node_modules/@react-native/virtualized-lists": {
       "version": "0.81.5",
       "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.81.5.tgz",
@@ -19776,6 +19821,15 @@
         "node": "*"
       }
     },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
+      }
+    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -20197,6 +20251,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
       }
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "react-native-fs": "^2.20.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-svg": "^15.15.4"
+    "react-native-svg": "^15.15.4",
+    "react-native-view-shot": "4.0.3"
   },
   "devDependencies": {
     "@testing-library/react-native": "^13.3.3",

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -1,0 +1,164 @@
+import React, { forwardRef } from "react";
+import { View, Text, StyleSheet } from "react-native";
+import type { Exercise } from "../lib/types";
+import { EXERCISE_LABELS } from "../lib/types";
+
+interface ShareCardProps {
+  exercise: Exercise;
+  reps: number;
+  score: number;
+  sets?: number;
+  isPersonalBest?: boolean;
+  date: string;
+}
+
+const ShareCard = forwardRef<View, ShareCardProps>(
+  ({ exercise, reps, score, sets, isPersonalBest, date }, ref) => {
+    const cleanRatio = Math.round((score / 100) * reps);
+    const formattedDate = new Date(date).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+
+    return (
+      <View ref={ref} style={styles.card} collapsable={false}>
+        {/* Background gradient effect */}
+        <View style={styles.bgAccent} />
+
+        {/* Header */}
+        <View style={styles.header}>
+          <Text style={styles.appName}>Gym Form Coach</Text>
+          <Text style={styles.date}>{formattedDate}</Text>
+        </View>
+
+        {/* Exercise */}
+        <Text style={styles.exercise}>{EXERCISE_LABELS[exercise]}</Text>
+
+        {/* Stats grid */}
+        <View style={styles.statsGrid}>
+          {sets != null && sets > 1 && (
+            <View style={styles.statBlock}>
+              <Text style={styles.statValue}>{sets}</Text>
+              <Text style={styles.statLabel}>Sets</Text>
+            </View>
+          )}
+          <View style={styles.statBlock}>
+            <Text style={styles.statValue}>{reps}</Text>
+            <Text style={styles.statLabel}>Total Reps</Text>
+          </View>
+          <View style={styles.statBlock}>
+            <Text style={[styles.statValue, { color: "#6366f1" }]}>
+              {score}%
+            </Text>
+            <Text style={styles.statLabel}>Form Score</Text>
+          </View>
+          <View style={styles.statBlock}>
+            <Text style={styles.statValue}>
+              {cleanRatio}/{reps}
+            </Text>
+            <Text style={styles.statLabel}>Clean Reps</Text>
+          </View>
+        </View>
+
+        {/* Personal best badge */}
+        {isPersonalBest && (
+          <View style={styles.pbBadge}>
+            <Text style={styles.pbText}>New Personal Best!</Text>
+          </View>
+        )}
+
+        {/* Watermark */}
+        <Text style={styles.watermark}>gymformcoach.app</Text>
+      </View>
+    );
+  }
+);
+
+ShareCard.displayName = "ShareCard";
+
+export default ShareCard;
+
+const styles = StyleSheet.create({
+  card: {
+    width: 360,
+    height: 360,
+    backgroundColor: "#0a0a0f",
+    borderRadius: 24,
+    padding: 28,
+    justifyContent: "space-between",
+    overflow: "hidden",
+  },
+  bgAccent: {
+    position: "absolute",
+    top: -60,
+    right: -60,
+    width: 200,
+    height: 200,
+    borderRadius: 100,
+    backgroundColor: "#6366f115",
+  },
+  header: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  appName: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#00E5FF",
+    letterSpacing: 0.5,
+  },
+  date: {
+    fontSize: 12,
+    color: "#ffffff50",
+  },
+  exercise: {
+    fontSize: 32,
+    fontWeight: "800",
+    color: "#ffffff",
+    marginTop: 8,
+  },
+  statsGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 16,
+    marginTop: 8,
+  },
+  statBlock: {
+    minWidth: 80,
+  },
+  statValue: {
+    fontSize: 28,
+    fontWeight: "800",
+    color: "#ffffff",
+  },
+  statLabel: {
+    fontSize: 11,
+    color: "#ffffff60",
+    fontWeight: "600",
+    textTransform: "uppercase",
+    letterSpacing: 0.5,
+    marginTop: 2,
+  },
+  pbBadge: {
+    alignSelf: "flex-start",
+    backgroundColor: "#FFD70020",
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderWidth: 1,
+    borderColor: "#FFD70040",
+  },
+  pbText: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#FFD700",
+  },
+  watermark: {
+    fontSize: 11,
+    color: "#ffffff25",
+    textAlign: "right",
+    fontWeight: "500",
+  },
+});

--- a/src/screens/Summary.tsx
+++ b/src/screens/Summary.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import {
   View,
   Text,
@@ -6,7 +6,10 @@ import {
   TouchableOpacity,
   SafeAreaView,
   ScrollView,
+  Alert,
 } from "react-native";
+import ViewShot from "react-native-view-shot";
+import * as Sharing from "expo-sharing";
 import type { NativeStackScreenProps } from "@react-navigation/native-stack";
 import type { SessionRecord } from "../lib/types";
 import {
@@ -14,8 +17,9 @@ import {
   DRILL_SUGGESTIONS,
   EXERCISE_LABELS,
 } from "../lib/types";
-import { addSession, loadSessions, findPreviousSession } from "../lib/sessionStorage";
+import { addSession, loadSessions, findPreviousSession, getPersonalBests } from "../lib/sessionStorage";
 import { detectFatigue, findBestWorstReps } from "../lib/formInsights";
+import ShareCard from "../components/ShareCard";
 import type { TrainStackParamList } from "../navigation";
 
 type SummaryProps = NativeStackScreenProps<TrainStackParamList, "Summary">;
@@ -32,11 +36,15 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
   const { exercise, reps, topFlag, score, repRecords, sets, durationMs } = route.params;
   const [delta, setDelta] = useState<number | null>(null);
   const [saved, setSaved] = useState(false);
+  const [isPersonalBest, setIsPersonalBest] = useState(false);
+  const [sharing, setSharing] = useState(false);
+  const shareRef = useRef<ViewShot>(null);
+  const sessionDate = useRef(new Date().toISOString());
 
   useEffect(() => {
     const session: SessionRecord = {
       id: Date.now().toString(),
-      date: new Date().toISOString(),
+      date: sessionDate.current,
       exercise,
       reps,
       topFlag,
@@ -52,6 +60,12 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
       if (prev) {
         setDelta(reps - prev.reps);
       }
+      // Check personal best
+      const bests = getPersonalBests(sessions);
+      const best = bests[exercise];
+      if (best && best.score === score && best.date === session.date) {
+        setIsPersonalBest(true);
+      }
     });
   }, [exercise, reps, topFlag, score, sets, durationMs]);
 
@@ -59,6 +73,27 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
   const drill = topFlag ? DRILL_SUGGESTIONS[topFlag] : null;
   const fatigue = detectFatigue(repRecords);
   const { bestRep, worstRep } = findBestWorstReps(repRecords);
+
+  const handleShare = async () => {
+    if (!shareRef.current?.capture) return;
+    setSharing(true);
+    try {
+      const uri = await shareRef.current.capture();
+      const canShare = await Sharing.isAvailableAsync();
+      if (!canShare) {
+        Alert.alert("Sharing not available", "Cannot share on this device.");
+        return;
+      }
+      await Sharing.shareAsync(uri, {
+        mimeType: "image/png",
+        dialogTitle: "Share your session",
+      });
+    } catch {
+      Alert.alert("Error", "Failed to capture or share image.");
+    } finally {
+      setSharing(false);
+    }
+  };
 
   const handleDone = () => {
     navigation.popToTop();
@@ -234,14 +269,41 @@ export default function SummaryScreen({ route, navigation }: SummaryProps) {
         )}
       </ScrollView>
 
-      <TouchableOpacity
-        style={styles.doneButton}
-        onPress={handleDone}
-        accessibilityRole="button"
-        accessibilityLabel="Done, return to home"
-      >
-        <Text style={styles.doneButtonText}>Done</Text>
-      </TouchableOpacity>
+      <View style={styles.buttonRow}>
+        <TouchableOpacity
+          style={styles.shareButton}
+          onPress={handleShare}
+          disabled={sharing}
+          accessibilityRole="button"
+          accessibilityLabel="Share session summary"
+        >
+          <Text style={styles.shareButtonText}>
+            {sharing ? "Sharing..." : "Share"}
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.doneButton}
+          onPress={handleDone}
+          accessibilityRole="button"
+          accessibilityLabel="Done, return to home"
+        >
+          <Text style={styles.doneButtonText}>Done</Text>
+        </TouchableOpacity>
+      </View>
+
+      {/* Offscreen ShareCard for capture */}
+      <View style={styles.offscreen} pointerEvents="none">
+        <ViewShot ref={shareRef} options={{ format: "png", quality: 1 }}>
+          <ShareCard
+            exercise={exercise}
+            reps={reps}
+            score={score}
+            sets={sets?.length}
+            isPersonalBest={isPersonalBest}
+            date={sessionDate.current}
+          />
+        </ViewShot>
+      </View>
     </SafeAreaView>
   );
 }
@@ -498,10 +560,29 @@ const styles = StyleSheet.create({
     flex: 1,
     textAlign: "right",
   },
-  doneButton: {
-    backgroundColor: "#6366f1",
-    marginHorizontal: 20,
+  buttonRow: {
+    flexDirection: "row",
+    paddingHorizontal: 20,
     marginBottom: 40,
+    gap: 12,
+  },
+  shareButton: {
+    flex: 1,
+    backgroundColor: "#1a1a24",
+    paddingVertical: 16,
+    borderRadius: 12,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+  },
+  shareButtonText: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#00E5FF",
+  },
+  doneButton: {
+    flex: 2,
+    backgroundColor: "#6366f1",
     paddingVertical: 16,
     borderRadius: 12,
     alignItems: "center",
@@ -510,5 +591,10 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: "600",
     color: "#ffffff",
+  },
+  offscreen: {
+    position: "absolute",
+    left: -9999,
+    top: -9999,
   },
 });


### PR DESCRIPTION
## Summary
- "Share" button on Summary screen captures a branded card as PNG
- Card shows: exercise, reps, form score, clean rep ratio, personal best badge, date
- Uses `react-native-view-shot` for on-device image capture (no external API)
- Opens native share sheet via `expo-sharing`
- Card rendered offscreen (not visible to user) at 360x360px

## Files changed
- `src/components/ShareCard.tsx` — branded card component with dark theme
- `src/screens/Summary.tsx` — share button, capture logic, personal best detection
- `package.json` — added react-native-view-shot

## Test plan
- [x] TypeScript clean
- [x] All 138 tests pass
- [x] Share button renders next to Done button
- [x] Card includes all required info (exercise, date, reps, score, clean ratio)

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)