### PR TITLE
feat: form improvement trends — score chart on History screen

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,10 +34,11 @@
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
         "react-native": "0.81.5",
+        "react-native-chart-kit": "^6.12.0",
         "react-native-fs": "^2.20.0",
         "react-native-safe-area-context": "~5.6.0",
         "react-native-screens": "~4.16.0",
-        "react-native-svg": "^15.15.4",
+        "react-native-svg": "15.12.1",
         "react-native-view-shot": "4.0.3"
       },
       "devDependencies": {
@@ -17004,7 +17005,6 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {
@@ -18141,6 +18141,15 @@
         "node": "20 || >=22"
       }
     },
+    "node_modules/paths-js": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/paths-js/-/paths-js-0.4.11.tgz",
+      "integrity": "sha512-3mqcLomDBXOo7Fo+UlaenG6f71bk1ZezPQy2JCmYHy2W2k5VKpP+Jbin9H0bjXynelTbglCqdFhSEkeIkKTYUA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.11.0"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -18203,6 +18212,12 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/point-in-polygon": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
+      "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
+      "license": "MIT"
     },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
@@ -18528,6 +18543,22 @@
         }
       }
     },
+    "node_modules/react-native-chart-kit": {
+      "version": "6.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-chart-kit/-/react-native-chart-kit-6.12.0.tgz",
+      "integrity": "sha512-nZLGyCFzZ7zmX0KjYeeSV1HKuPhl1wOMlTAqa0JhlyW62qV/1ZPXHgT8o9s8mkFaGxdqbspOeuaa6I9jUQDgnA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.13",
+        "paths-js": "^0.4.10",
+        "point-in-polygon": "^1.0.1"
+      },
+      "peerDependencies": {
+        "react": "> 16.7.0",
+        "react-native": ">= 0.50.0",
+        "react-native-svg": "> 6.4.1"
+      }
+    },
     "node_modules/react-native-fs": {
       "version": "2.20.0",
       "resolved": "https://registry.npmjs.org/react-native-fs/-/react-native-fs-2.20.0.tgz",
@@ -18583,9 +18614,9 @@
       }
     },
     "node_modules/react-native-svg": {
-      "version": "15.15.4",
-      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.15.4.tgz",
-      "integrity": "sha512-boT/vIRgj6zZKBpfTPJJiYWMbZE9duBMOwPK6kCSTgxsS947IFMOq9OgIFkpWZTB7t229H24pDRkh3W9ZK/J1A==",
+      "version": "15.12.1",
+      "resolved": "https://registry.npmjs.org/react-native-svg/-/react-native-svg-15.12.1.tgz",
+      "integrity": "sha512-vCuZJDf8a5aNC2dlMovEv4Z0jjEUET53lm/iILFnFewa15b4atjVxU6Wirm6O9y6dEsdjDZVD7Q3QM4T1wlI8g==",
       "license": "MIT",
       "dependencies": {
         "css-select": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -37,10 +37,11 @@
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",
     "react-native": "0.81.5",
+    "react-native-chart-kit": "^6.12.0",
     "react-native-fs": "^2.20.0",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-svg": "^15.15.4",
+    "react-native-svg": "15.12.1",
     "react-native-view-shot": "4.0.3"
   },
   "devDependencies": {

--- a/src/__tests__/trendData.test.ts
+++ b/src/__tests__/trendData.test.ts
@@ -1,0 +1,98 @@
+import { computeScoreTrend } from "../lib/trendData";
+import type { SessionRecord } from "../lib/types";
+
+function makeSession(overrides: Partial<SessionRecord> = {}): SessionRecord {
+  return {
+    id: Math.random().toString(),
+    date: "2026-04-01T12:00:00.000Z",
+    exercise: "squat",
+    reps: 5,
+    topFlag: null,
+    score: 80,
+    ...overrides,
+  };
+}
+
+describe("computeScoreTrend", () => {
+  it("returns empty array for no sessions", () => {
+    expect(computeScoreTrend([], null, 4)).toEqual([]);
+  });
+
+  it("groups sessions by day and averages scores", () => {
+    const now = new Date();
+    const today = now.toISOString().slice(0, 10);
+    const sessions = [
+      makeSession({ date: `${today}T10:00:00.000Z`, score: 80 }),
+      makeSession({ date: `${today}T14:00:00.000Z`, score: 60 }),
+    ];
+    const result = computeScoreTrend(sessions, null, 4);
+    expect(result).toHaveLength(1);
+    expect(result[0].score).toBe(70); // (80+60)/2
+    expect(result[0].sessionCount).toBe(2);
+  });
+
+  it("filters by exercise when specified", () => {
+    const now = new Date();
+    const today = now.toISOString().slice(0, 10);
+    const sessions = [
+      makeSession({ date: `${today}T10:00:00.000Z`, exercise: "squat", score: 90 }),
+      makeSession({ date: `${today}T11:00:00.000Z`, exercise: "deadlift", score: 60 }),
+    ];
+    const result = computeScoreTrend(sessions, "squat", 4);
+    expect(result).toHaveLength(1);
+    expect(result[0].score).toBe(90);
+  });
+
+  it("returns all exercises when filter is null", () => {
+    const now = new Date();
+    const today = now.toISOString().slice(0, 10);
+    const sessions = [
+      makeSession({ date: `${today}T10:00:00.000Z`, exercise: "squat", score: 90 }),
+      makeSession({ date: `${today}T11:00:00.000Z`, exercise: "deadlift", score: 70 }),
+    ];
+    const result = computeScoreTrend(sessions, null, 4);
+    expect(result).toHaveLength(1);
+    expect(result[0].score).toBe(80); // (90+70)/2
+  });
+
+  it("excludes sessions older than weeksBack", () => {
+    const old = new Date();
+    old.setDate(old.getDate() - 35); // 5 weeks ago
+    const recent = new Date();
+    const sessions = [
+      makeSession({ date: old.toISOString(), score: 50 }),
+      makeSession({ date: recent.toISOString(), score: 90 }),
+    ];
+    const result = computeScoreTrend(sessions, null, 4);
+    expect(result).toHaveLength(1);
+    expect(result[0].score).toBe(90);
+  });
+
+  it("sorts results by date ascending", () => {
+    const now = new Date();
+    const day1 = new Date(now);
+    day1.setDate(day1.getDate() - 2);
+    const day2 = new Date(now);
+    day2.setDate(day2.getDate() - 1);
+    const sessions = [
+      makeSession({ date: day2.toISOString(), score: 80 }),
+      makeSession({ date: day1.toISOString(), score: 70 }),
+    ];
+    const result = computeScoreTrend(sessions, null, 4);
+    expect(result).toHaveLength(2);
+    expect(result[0].score).toBe(70); // older first
+    expect(result[1].score).toBe(80);
+  });
+
+  it("rounds averaged scores", () => {
+    const now = new Date();
+    const today = now.toISOString().slice(0, 10);
+    const sessions = [
+      makeSession({ date: `${today}T10:00:00.000Z`, score: 77 }),
+      makeSession({ date: `${today}T11:00:00.000Z`, score: 78 }),
+      makeSession({ date: `${today}T12:00:00.000Z`, score: 79 }),
+    ];
+    const result = computeScoreTrend(sessions, null, 4);
+    expect(result[0].score).toBe(78); // (77+78+79)/3 = 78
+  });
+});

--- a/src/components/FormTrendsChart.tsx
+++ b/src/components/FormTrendsChart.tsx
@@ -1,0 +1,208 @@
+import React, { useState, useMemo } from "react";
+import { View, Text, StyleSheet, TouchableOpacity, Dimensions } from "react-native";
+import { LineChart } from "react-native-chart-kit";
+import type { Exercise, SessionRecord } from "../lib/types";
+import { EXERCISE_LABELS } from "../lib/types";
+import { computeScoreTrend } from "../lib/trendData";
+
+const SCREEN_WIDTH = Dimensions.get("window").width;
+const CHART_WIDTH = SCREEN_WIDTH - 40; // 20px padding each side
+
+const WEEK_OPTIONS = [4, 8, 12] as const;
+const EXERCISES: (Exercise | null)[] = [null, "squat", "deadlift", "pushup", "overheadPress"];
+
+interface FormTrendsChartProps {
+  sessions: SessionRecord[];
+}
+
+export default function FormTrendsChart({ sessions }: FormTrendsChartProps) {
+  const [weeksBack, setWeeksBack] = useState<4 | 8 | 12>(4);
+  const [exercise, setExercise] = useState<Exercise | null>(null);
+
+  const trendData = useMemo(
+    () => computeScoreTrend(sessions, exercise, weeksBack),
+    [sessions, exercise, weeksBack]
+  );
+
+  if (trendData.length < 2) {
+    return (
+      <View style={styles.container}>
+        <Text style={styles.title}>Form Trends</Text>
+        <View style={styles.emptyState}>
+          <Text style={styles.emptyText}>
+            Complete 3+ sessions to see your trends
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  const labels = trendData.map((p) => {
+    const d = new Date(p.date + "T00:00:00");
+    return `${d.getMonth() + 1}/${d.getDate()}`;
+  });
+  const data = trendData.map((p) => p.score);
+
+  // Show max ~8 labels to avoid crowding
+  const labelStep = Math.max(1, Math.ceil(labels.length / 8));
+  const displayLabels = labels.map((l, i) => (i % labelStep === 0 ? l : ""));
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Form Trends</Text>
+
+      {/* Exercise filter */}
+      <View style={styles.filterRow}>
+        {EXERCISES.map((ex) => (
+          <TouchableOpacity
+            key={ex ?? "all"}
+            style={[styles.filterPill, exercise === ex && styles.filterPillActive]}
+            onPress={() => setExercise(ex)}
+          >
+            <Text
+              style={[
+                styles.filterText,
+                exercise === ex && styles.filterTextActive,
+              ]}
+            >
+              {ex ? EXERCISE_LABELS[ex] : "All"}
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+
+      {/* Chart */}
+      <LineChart
+        data={{
+          labels: displayLabels,
+          datasets: [{ data, strokeWidth: 2 }],
+        }}
+        width={CHART_WIDTH}
+        height={180}
+        yAxisSuffix="%"
+        yAxisInterval={1}
+        fromZero={false}
+        chartConfig={{
+          backgroundColor: "#1a1a24",
+          backgroundGradientFrom: "#1a1a24",
+          backgroundGradientTo: "#1a1a24",
+          decimalPlaces: 0,
+          color: (opacity = 1) => `rgba(99, 102, 241, ${opacity})`,
+          labelColor: () => "rgba(255, 255, 255, 0.4)",
+          propsForDots: {
+            r: "4",
+            strokeWidth: "2",
+            stroke: "#6366f1",
+          },
+          propsForBackgroundLines: {
+            stroke: "#ffffff10",
+          },
+        }}
+        bezier
+        style={styles.chart}
+      />
+
+      {/* Week range selector */}
+      <View style={styles.weekRow}>
+        {WEEK_OPTIONS.map((w) => (
+          <TouchableOpacity
+            key={w}
+            style={[styles.weekPill, weeksBack === w && styles.weekPillActive]}
+            onPress={() => setWeeksBack(w)}
+          >
+            <Text
+              style={[
+                styles.weekText,
+                weeksBack === w && styles.weekTextActive,
+              ]}
+            >
+              {w}w
+            </Text>
+          </TouchableOpacity>
+        ))}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: "#1a1a24",
+    borderRadius: 16,
+    padding: 16,
+    marginBottom: 20,
+  },
+  title: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ffffff60",
+    textTransform: "uppercase",
+    letterSpacing: 1,
+    marginBottom: 12,
+  },
+  filterRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+    marginBottom: 12,
+  },
+  filterPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 5,
+    borderRadius: 12,
+    backgroundColor: "#0a0a0f",
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+  },
+  filterPillActive: {
+    borderColor: "#6366f1",
+    backgroundColor: "#6366f115",
+  },
+  filterText: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: "#ffffff50",
+  },
+  filterTextActive: {
+    color: "#6366f1",
+  },
+  chart: {
+    borderRadius: 12,
+    marginLeft: -16,
+  },
+  weekRow: {
+    flexDirection: "row",
+    justifyContent: "center",
+    gap: 8,
+    marginTop: 8,
+  },
+  weekPill: {
+    paddingHorizontal: 14,
+    paddingVertical: 6,
+    borderRadius: 12,
+    backgroundColor: "#0a0a0f",
+    borderWidth: 1,
+    borderColor: "#2a2a3a",
+  },
+  weekPillActive: {
+    borderColor: "#00E5FF",
+    backgroundColor: "#00E5FF15",
+  },
+  weekText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#ffffff50",
+  },
+  weekTextActive: {
+    color: "#00E5FF",
+  },
+  emptyState: {
+    paddingVertical: 30,
+    alignItems: "center",
+  },
+  emptyText: {
+    fontSize: 14,
+    color: "#ffffff40",
+    textAlign: "center",
+  },
+});

--- a/src/lib/trendData.ts
+++ b/src/lib/trendData.ts
@@ -1,0 +1,48 @@
+import type { Exercise, SessionRecord } from "./types";
+
+export interface TrendPoint {
+  date: string; // YYYY-MM-DD
+  score: number;
+  sessionCount: number;
+}
+
+/**
+ * Compute daily average form scores for the given sessions.
+ * Returns points sorted ascending by date.
+ */
+export function computeScoreTrend(
+  sessions: SessionRecord[],
+  exercise: Exercise | null,
+  weeksBack: number
+): TrendPoint[] {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - weeksBack * 7);
+  cutoff.setHours(0, 0, 0, 0);
+
+  const filtered = sessions.filter((s) => {
+    if (exercise && s.exercise !== exercise) return false;
+    return new Date(s.date) >= cutoff;
+  });
+
+  // Group by day
+  const byDay = new Map<string, { total: number; count: number }>();
+  for (const s of filtered) {
+    const day = s.date.slice(0, 10);
+    const existing = byDay.get(day);
+    if (existing) {
+      existing.total += s.score;
+      existing.count += 1;
+    } else {
+      byDay.set(day, { total: s.score, count: 1 });
+    }
+  }
+
+  // Convert to sorted array
+  return Array.from(byDay.entries())
+    .map(([date, { total, count }]) => ({
+      date,
+      score: Math.round(total / count),
+      sessionCount: count,
+    }))
+    .sort((a, b) => (a.date < b.date ? -1 : 1));
+}

--- a/src/screens/History.tsx
+++ b/src/screens/History.tsx
@@ -23,6 +23,7 @@ import {
   getTotalReps,
   getScoreTrend,
 } from "../lib/sessionStorage";
+import FormTrendsChart from "../components/FormTrendsChart";
 
 const MAX_DISPLAY = 50;
 
@@ -244,6 +245,7 @@ export default function HistoryScreen() {
   const ListHeader = () => (
     <>
       <StatsHeader sessions={allSessions} />
+      <FormTrendsChart sessions={allSessions} />
       <PersonalBests
         sessions={allSessions}
         exerciseFilter={exerciseFilter}


### PR DESCRIPTION
## Summary
- Line chart showing daily average form scores over time on History screen
- Exercise filter: All / Squat / Deadlift / Push-up / Overhead Press
- Time range: 4 weeks (default), 8 weeks, 12 weeks
- Empty state: "Complete 3+ sessions to see your trends"
- Uses react-native-chart-kit + react-native-svg (lightweight)

## Files changed
- `src/lib/trendData.ts` — compute daily average scores from sessions
- `src/components/FormTrendsChart.tsx` — chart with exercise filter + week selector
- `src/screens/History.tsx` — integrated chart into ListHeader
- `src/__tests__/trendData.test.ts` — 7 tests for trend computation

## Test plan
- [x] 7 new tests for trend data (grouping, filtering, sorting, rounding)
- [x] All 145 tests pass
- [x] TypeScript clean

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)