### PR TITLE
fix: bench press integration — confidence + trends

### DIFF
--- a/src/components/FormTrendsChart.tsx
+++ b/src/components/FormTrendsChart.tsx
@@ -9,7 +9,7 @@ const SCREEN_WIDTH = Dimensions.get("window").width;
 const CHART_WIDTH = SCREEN_WIDTH - 40; // 20px padding each side
 
 const WEEK_OPTIONS = [4, 8, 12] as const;
-const EXERCISES: (Exercise | null)[] = [null, "squat", "deadlift", "pushup", "overheadPress"];
+const EXERCISES: (Exercise | null)[] = [null, "squat", "deadlift", "pushup", "overheadPress", "benchPress"];
 
 interface FormTrendsChartProps {
   sessions: SessionRecord[];

--- a/src/lib/poseConfidence.ts
+++ b/src/lib/poseConfidence.ts
@@ -40,6 +40,14 @@ const EXERCISE_LANDMARKS: Record<Exercise, string[]> = {
     "left_wrist",
     "right_wrist",
   ],
+  benchPress: [
+    "left_shoulder",
+    "right_shoulder",
+    "left_elbow",
+    "right_elbow",
+    "left_wrist",
+    "right_wrist",
+  ],
 };
 
 export const CONFIDENCE_GOOD = 0.7;


### PR DESCRIPTION
## Summary
Integration fix after #79 (bench press) added `benchPress` to the `Exercise` type union.
- Added `benchPress` landmarks to `poseConfidence.ts` (shoulders, elbows, wrists)
- Added `benchPress` to FormTrendsChart exercise filter

## Test plan
- [x] All 160 tests pass
- [x] TypeScript clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)