### PR TITLE
feat: form trend chart — tooltip, dashed trend line, empty state fix (#82)

### DIFF
--- a/src/components/FormTrendsChart.tsx
+++ b/src/components/FormTrendsChart.tsx
@@ -1,36 +1,95 @@
 import React, { useState, useMemo } from "react";
-import { View, Text, StyleSheet, TouchableOpacity, Dimensions } from "react-native";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TouchableOpacity,
+  Dimensions,
+} from "react-native";
 import { LineChart } from "react-native-chart-kit";
 import type { Exercise, SessionRecord } from "../lib/types";
 import { EXERCISE_LABELS } from "../lib/types";
 import { computeScoreTrend } from "../lib/trendData";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
-const CHART_WIDTH = SCREEN_WIDTH - 40; // 20px padding each side
+const CHART_WIDTH = SCREEN_WIDTH - 40;
+const CHART_HEIGHT = 180;
+// react-native-chart-kit internal left padding — used to position tooltip
+const CHART_PADDING_LEFT = 55;
 
 const WEEK_OPTIONS = [4, 8, 12] as const;
-const EXERCISES: (Exercise | null)[] = [null, "squat", "deadlift", "pushup", "overheadPress", "benchPress"];
+const EXERCISES: (Exercise | null)[] = [
+  null,
+  "squat",
+  "deadlift",
+  "pushup",
+  "overheadPress",
+  "benchPress",
+];
+
+interface TooltipState {
+  x: number;
+  y: number;
+  index: number;
+}
 
 interface FormTrendsChartProps {
   sessions: SessionRecord[];
 }
 
+/** Compute linear regression y = mx + b over the data points. */
+function linearTrend(values: number[]): number[] {
+  const n = values.length;
+  if (n < 2) return values.slice();
+  const xs = values.map((_, i) => i);
+  const sumX = xs.reduce((a, b) => a + b, 0);
+  const sumY = values.reduce((a, b) => a + b, 0);
+  const sumXY = xs.reduce((acc, x, i) => acc + x * values[i], 0);
+  const sumX2 = xs.reduce((acc, x) => acc + x * x, 0);
+  const m = (n * sumXY - sumX * sumY) / (n * sumX2 - sumX * sumX);
+  const b = (sumY - m * sumX) / n;
+  return xs.map((x) => Math.min(100, Math.max(0, Math.round(m * x + b))));
+}
+
 export default function FormTrendsChart({ sessions }: FormTrendsChartProps) {
   const [weeksBack, setWeeksBack] = useState<4 | 8 | 12>(4);
   const [exercise, setExercise] = useState<Exercise | null>(null);
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
 
   const trendData = useMemo(
     () => computeScoreTrend(sessions, exercise, weeksBack),
     [sessions, exercise, weeksBack]
   );
 
-  if (trendData.length < 2) {
+  // Dismiss tooltip when filter changes
+  const handleExerciseChange = (ex: Exercise | null) => {
+    setExercise(ex);
+    setTooltip(null);
+  };
+
+  const handleWeeksChange = (w: 4 | 8 | 12) => {
+    setWeeksBack(w);
+    setTooltip(null);
+  };
+
+  // Empty state: require at least 3 raw sessions (not aggregated days)
+  const relevantSessions = useMemo(() => {
+    const cutoff = new Date();
+    cutoff.setDate(cutoff.getDate() - weeksBack * 7);
+    cutoff.setHours(0, 0, 0, 0);
+    return sessions.filter((s) => {
+      if (exercise && s.exercise !== exercise) return false;
+      return new Date(s.date) >= cutoff;
+    });
+  }, [sessions, exercise, weeksBack]);
+
+  if (relevantSessions.length < 3) {
     return (
       <View style={styles.container}>
         <Text style={styles.title}>Form Trends</Text>
         <View style={styles.emptyState}>
           <Text style={styles.emptyText}>
-            Complete 3+ sessions to see your trends
+            Complete 3 sessions to see your form trend
           </Text>
         </View>
       </View>
@@ -41,11 +100,14 @@ export default function FormTrendsChart({ sessions }: FormTrendsChartProps) {
     const d = new Date(p.date + "T00:00:00");
     return `${d.getMonth() + 1}/${d.getDate()}`;
   });
-  const data = trendData.map((p) => p.score);
+  const scoreData = trendData.map((p) => p.score);
+  const trendLine = linearTrend(scoreData);
 
   // Show max ~8 labels to avoid crowding
   const labelStep = Math.max(1, Math.ceil(labels.length / 8));
   const displayLabels = labels.map((l, i) => (i % labelStep === 0 ? l : ""));
+
+  const activePoint = tooltip !== null ? trendData[tooltip.index] : null;
 
   return (
     <View style={styles.container}>
@@ -56,8 +118,11 @@ export default function FormTrendsChart({ sessions }: FormTrendsChartProps) {
         {EXERCISES.map((ex) => (
           <TouchableOpacity
             key={ex ?? "all"}
-            style={[styles.filterPill, exercise === ex && styles.filterPillActive]}
-            onPress={() => setExercise(ex)}
+            style={[
+              styles.filterPill,
+              exercise === ex && styles.filterPillActive,
+            ]}
+            onPress={() => handleExerciseChange(ex)}
           >
             <Text
               style={[
@@ -71,44 +136,107 @@ export default function FormTrendsChart({ sessions }: FormTrendsChartProps) {
         ))}
       </View>
 
-      {/* Chart */}
-      <LineChart
-        data={{
-          labels: displayLabels,
-          datasets: [{ data, strokeWidth: 2 }],
-        }}
-        width={CHART_WIDTH}
-        height={180}
-        yAxisSuffix="%"
-        yAxisInterval={1}
-        fromZero={false}
-        chartConfig={{
-          backgroundColor: "#1a1a24",
-          backgroundGradientFrom: "#1a1a24",
-          backgroundGradientTo: "#1a1a24",
-          decimalPlaces: 0,
-          color: (opacity = 1) => `rgba(99, 102, 241, ${opacity})`,
-          labelColor: () => "rgba(255, 255, 255, 0.4)",
-          propsForDots: {
-            r: "4",
-            strokeWidth: "2",
-            stroke: "#6366f1",
-          },
-          propsForBackgroundLines: {
-            stroke: "#ffffff10",
-          },
-        }}
-        bezier
-        style={styles.chart}
-      />
+      {/* Chart + tooltip wrapper */}
+      <View style={styles.chartWrapper}>
+        <LineChart
+          data={{
+            labels: displayLabels,
+            datasets: [
+              {
+                data: scoreData,
+                strokeWidth: 2,
+                color: (opacity = 1) => `rgba(99, 102, 241, ${opacity})`,
+              },
+              {
+                data: trendLine,
+                strokeWidth: 1.5,
+                strokeDashArray: [6, 4],
+                color: (opacity = 1) => `rgba(0, 229, 255, ${opacity * 0.7})`,
+                withDots: false,
+              } as any,
+            ],
+          }}
+          width={CHART_WIDTH}
+          height={CHART_HEIGHT}
+          yAxisSuffix="%"
+          yAxisInterval={1}
+          fromZero={false}
+          onDataPointClick={({ index, x, y }) => {
+            setTooltip((prev) =>
+              prev?.index === index ? null : { x, y, index }
+            );
+          }}
+          chartConfig={{
+            backgroundColor: "#1a1a24",
+            backgroundGradientFrom: "#1a1a24",
+            backgroundGradientTo: "#1a1a24",
+            decimalPlaces: 0,
+            color: (opacity = 1) => `rgba(99, 102, 241, ${opacity})`,
+            labelColor: () => "rgba(255, 255, 255, 0.4)",
+            propsForDots: {
+              r: "5",
+              strokeWidth: "2",
+              stroke: "#6366f1",
+            },
+            propsForBackgroundLines: {
+              stroke: "#ffffff10",
+            },
+          }}
+          bezier
+          style={styles.chart}
+        />
+
+        {/* Tooltip overlay */}
+        {tooltip !== null && activePoint && (
+          <View
+            style={[
+              styles.tooltip,
+              {
+                left: Math.min(
+                  tooltip.x - CHART_PADDING_LEFT - 4,
+                  CHART_WIDTH - 130
+                ),
+                top: Math.max(tooltip.y - 72, 0),
+              },
+            ]}
+          >
+            <Text style={styles.tooltipDate}>
+              {new Date(activePoint.date + "T00:00:00").toLocaleDateString(
+                undefined,
+                { month: "short", day: "numeric" }
+              )}
+            </Text>
+            <Text style={styles.tooltipScore}>{activePoint.score}%</Text>
+            <Text style={styles.tooltipSessions}>
+              {activePoint.sessionCount}{" "}
+              {activePoint.sessionCount === 1 ? "session" : "sessions"}
+            </Text>
+          </View>
+        )}
+      </View>
+
+      {/* Legend */}
+      <View style={styles.legendRow}>
+        <View style={styles.legendItem}>
+          <View style={[styles.legendDot, { backgroundColor: "#6366f1" }]} />
+          <Text style={styles.legendText}>Score</Text>
+        </View>
+        <View style={styles.legendItem}>
+          <View style={styles.legendDash} />
+          <Text style={styles.legendText}>Trend</Text>
+        </View>
+      </View>
 
       {/* Week range selector */}
       <View style={styles.weekRow}>
         {WEEK_OPTIONS.map((w) => (
           <TouchableOpacity
             key={w}
-            style={[styles.weekPill, weeksBack === w && styles.weekPillActive]}
-            onPress={() => setWeeksBack(w)}
+            style={[
+              styles.weekPill,
+              weeksBack === w && styles.weekPillActive,
+            ]}
+            onPress={() => handleWeeksChange(w)}
           >
             <Text
               style={[
@@ -166,15 +294,71 @@ const styles = StyleSheet.create({
   filterTextActive: {
     color: "#6366f1",
   },
+  chartWrapper: {
+    position: "relative",
+  },
   chart: {
     borderRadius: 12,
     marginLeft: -16,
+  },
+  tooltip: {
+    position: "absolute",
+    backgroundColor: "#0a0a0f",
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderWidth: 1,
+    borderColor: "#6366f140",
+    minWidth: 100,
+    zIndex: 10,
+  },
+  tooltipDate: {
+    fontSize: 11,
+    color: "#ffffff50",
+    marginBottom: 2,
+  },
+  tooltipScore: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#6366f1",
+  },
+  tooltipSessions: {
+    fontSize: 11,
+    color: "#ffffff40",
+    marginTop: 2,
+  },
+  legendRow: {
+    flexDirection: "row",
+    gap: 16,
+    marginTop: 6,
+    marginBottom: 2,
+    paddingLeft: 4,
+  },
+  legendItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 5,
+  },
+  legendDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  legendDash: {
+    width: 16,
+    height: 2,
+    backgroundColor: "#00E5FF",
+    borderRadius: 1,
+  },
+  legendText: {
+    fontSize: 11,
+    color: "#ffffff40",
   },
   weekRow: {
     flexDirection: "row",
     justifyContent: "center",
     gap: 8,
-    marginTop: 8,
+    marginTop: 10,
   },
   weekPill: {
     paddingHorizontal: 14,


### PR DESCRIPTION
## Summary
- Adds dashed linear regression trend line so users see improvement direction even with noisy sessions
- Tap any data point to see a tooltip with date, avg score, and session count
- Fixes empty state: now requires 3 raw sessions (was checking < 2 aggregated day-points)
- Adds score/trend legend below chart

## Changes
- `src/components/FormTrendsChart.tsx` — added tooltip state + absolute overlay, `linearTrend()` helper, second dashed dataset, empty state uses raw session count

## Test plan
- [ ] Build with EAS / Expo simulator
- [ ] History screen shows chart above session list with 3+ sessions
- [ ] Tap data point → tooltip appears; tap same point again → dismisses
- [ ] Exercise filter pills update chart correctly
- [ ] Dashed cyan line visible running through the chart
- [ ] With < 3 sessions: empty state "Complete 3 sessions to see your form trend"
- [ ] `npx tsc --noEmit` — zero errors ✓

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)