### PR TITLE
feat: interactive camera positioning step in onboarding (#86)

### DIFF
--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -10,12 +10,15 @@ import {
 } from "react-native";
 import type { NativeStackNavigationProp } from "@react-navigation/native-stack";
 import { useIsFocused } from "@react-navigation/native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { Exercise } from "../lib/types";
 import { EXERCISE_LABELS } from "../lib/types";
 import type { TrainStackParamList } from "../navigation";
 import { trackExerciseSelected } from "../lib/analytics";
 import { loadSessions, getWorkoutStreak } from "../lib/sessionStorage";
 import StreakWidget from "../components/StreakWidget";
+
+const HOME_EXERCISE_TIP_KEY = "homeFirstExerciseTipSeen";
 
 type HomeProps = {
   navigation: NativeStackNavigationProp<TrainStackParamList, "Home">;
@@ -32,6 +35,7 @@ const EXERCISES: { type: Exercise; emoji: string; description: string }[] = [
 export default function HomeScreen({ navigation }: HomeProps) {
   const isFocused = useIsFocused();
   const [streak, setStreak] = useState({ current: 0, best: 0 });
+  const [showExerciseTip, setShowExerciseTip] = useState(false);
 
   const refreshStreak = useCallback(async () => {
     const sessions = await loadSessions();
@@ -43,6 +47,13 @@ export default function HomeScreen({ navigation }: HomeProps) {
       refreshStreak();
     }
   }, [isFocused, refreshStreak]);
+
+  // Show one-time "camera guide will appear first" tip after onboarding
+  useEffect(() => {
+    AsyncStorage.getItem(HOME_EXERCISE_TIP_KEY).then((seen) => {
+      if (!seen) setShowExerciseTip(true);
+    });
+  }, []);
 
   return (
     <SafeAreaView style={styles.container}>
@@ -72,12 +83,23 @@ export default function HomeScreen({ navigation }: HomeProps) {
       </View>
 
       <ScrollView contentContainerStyle={styles.grid} showsVerticalScrollIndicator={false}>
+        {showExerciseTip && (
+          <View style={styles.exerciseTip} accessible accessibilityLiveRegion="polite">
+            <Text style={styles.exerciseTipText}>
+              📷 Tap to start — your camera guide will appear first
+            </Text>
+          </View>
+        )}
         {EXERCISES.map(({ type, emoji, description }) => (
           <TouchableOpacity
             key={type}
             style={styles.card}
             activeOpacity={0.7}
-            onPress={() => {
+            onPress={async () => {
+              if (showExerciseTip) {
+                setShowExerciseTip(false);
+                await AsyncStorage.setItem(HOME_EXERCISE_TIP_KEY, "true");
+              }
               trackExerciseSelected(type);
               navigation.navigate("Session", { exerciseType: type });
             }}
@@ -195,5 +217,20 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: "#ffffff70",
     lineHeight: 20,
+  },
+  exerciseTip: {
+    backgroundColor: "#00E5FF15",
+    borderRadius: 10,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: "#00E5FF30",
+  },
+  exerciseTipText: {
+    fontSize: 13,
+    color: "#00E5FFcc",
+    fontWeight: "500",
+    textAlign: "center",
   },
 });

--- a/src/screens/Onboarding.tsx
+++ b/src/screens/Onboarding.tsx
@@ -14,6 +14,7 @@ import { Camera } from "expo-camera";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import type { Exercise } from "../lib/types";
 import { EXERCISE_LABELS } from "../lib/types";
+import OnboardingCameraSetup, { CAMERA_SETUP_KEY } from "./OnboardingCameraSetup";
 
 export const ONBOARDING_KEY = "hasCompletedOnboarding";
 
@@ -56,7 +57,7 @@ const EXERCISES: { type: Exercise; emoji: string }[] = [
   { type: "benchPress", emoji: "🔩" },
 ];
 
-type OnboardingPhase = "slides" | "camera" | "exercise" | "ready";
+type OnboardingPhase = "slides" | "camera" | "camera-setup" | "exercise" | "ready";
 
 type Props = {
   onComplete: (firstExercise?: Exercise) => void;
@@ -98,7 +99,13 @@ export default function OnboardingScreen({ onComplete }: Props) {
 
   const handleCameraPermission = useCallback(async () => {
     await Camera.requestCameraPermissionsAsync();
-    setPhase("exercise");
+    // Skip camera-setup if already completed/skipped in a prior launch
+    const setupDone = await AsyncStorage.getItem(CAMERA_SETUP_KEY);
+    if (setupDone) {
+      setPhase("exercise");
+    } else {
+      setPhase("camera-setup");
+    }
   }, []);
 
   const handleSkipCamera = useCallback(() => {
@@ -146,6 +153,16 @@ export default function OnboardingScreen({ onComplete }: Props) {
           </TouchableOpacity>
         </View>
       </SafeAreaView>
+    );
+  }
+
+  // Camera setup phase
+  if (phase === "camera-setup") {
+    return (
+      <OnboardingCameraSetup
+        onComplete={() => setPhase("exercise")}
+        onSkip={() => setPhase("exercise")}
+      />
     );
   }
 

--- a/src/screens/OnboardingCameraSetup.tsx
+++ b/src/screens/OnboardingCameraSetup.tsx
@@ -1,0 +1,353 @@
+/**
+ * OnboardingCameraSetup.tsx
+ *
+ * Interactive camera positioning step added after camera permission.
+ * Shows a live camera preview with a body guide outline.
+ * Detects when the user's full body is visible (confidence > 0.6 for 2s).
+ * Falls back to allowing "Continue" after 30 seconds.
+ *
+ * Shown only once — completion state stored in AsyncStorage.
+ */
+
+import React, { useRef, useState, useEffect, useCallback } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  SafeAreaView,
+  TouchableOpacity,
+  Dimensions,
+} from "react-native";
+import { CameraView } from "expo-camera";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Haptics from "expo-haptics";
+import { usePoseEstimation } from "../hooks/usePoseEstimation";
+import type { Pose } from "@tensorflow-models/pose-detection";
+
+export const CAMERA_SETUP_KEY = "onboardingCameraSetupComplete";
+
+const { height: SCREEN_HEIGHT } = Dimensions.get("window");
+
+// Confidence threshold to be considered "ready"
+const READY_THRESHOLD = 0.6;
+// Seconds at threshold before "Continue" auto-enables
+const READY_HOLD_SECONDS = 2;
+// Seconds before the 30s fallback kicks in
+const FALLBACK_SECONDS = 30;
+
+/** Compute average confidence across all detected keypoints. */
+function computeGeneralConfidence(pose: Pose): number {
+  const kps = pose.keypoints.filter((kp) => kp.score != null && kp.score > 0);
+  if (kps.length === 0) return 0;
+  const sum = kps.reduce((acc, kp) => acc + (kp.score ?? 0), 0);
+  return sum / kps.length;
+}
+
+interface Props {
+  onComplete: () => void;
+  onSkip: () => void;
+}
+
+export default function OnboardingCameraSetup({ onComplete, onSkip }: Props) {
+  const cameraRef = useRef<CameraView>(null);
+  const [isCameraReady, setIsCameraReady] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+  const [canContinue, setCanContinue] = useState(false);
+  const [elapsed, setElapsed] = useState(0); // seconds shown to user
+  const readyHoldRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hapticFiredRef = useRef(false);
+
+  const { poses, modelReady } = usePoseEstimation({
+    cameraRef,
+    isCameraReady,
+  });
+
+  // 30-second fallback timer
+  useEffect(() => {
+    fallbackRef.current = setTimeout(() => {
+      setCanContinue(true);
+    }, FALLBACK_SECONDS * 1000);
+    return () => {
+      if (fallbackRef.current) clearTimeout(fallbackRef.current);
+    };
+  }, []);
+
+  // Elapsed seconds counter (for UX feedback)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setElapsed((e) => e + 1);
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  // Evaluate pose confidence
+  useEffect(() => {
+    if (!modelReady || poses.length === 0) {
+      // Model not ready or no pose — reset hold timer
+      if (readyHoldRef.current) {
+        clearTimeout(readyHoldRef.current);
+        readyHoldRef.current = null;
+      }
+      setIsReady(false);
+      return;
+    }
+
+    const confidence = computeGeneralConfidence(poses[0]);
+    const poseReady = confidence >= READY_THRESHOLD;
+
+    if (poseReady && !isReady) {
+      setIsReady(true);
+      if (!hapticFiredRef.current) {
+        Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
+        hapticFiredRef.current = true;
+      }
+      // Start hold timer
+      readyHoldRef.current = setTimeout(() => {
+        setCanContinue(true);
+      }, READY_HOLD_SECONDS * 1000);
+    } else if (!poseReady && isReady) {
+      // Lost confidence — cancel hold timer, reset haptic flag
+      setIsReady(false);
+      hapticFiredRef.current = false;
+      if (readyHoldRef.current) {
+        clearTimeout(readyHoldRef.current);
+        readyHoldRef.current = null;
+      }
+    }
+  }, [poses, modelReady, isReady]);
+
+  const handleComplete = useCallback(async () => {
+    await AsyncStorage.setItem(CAMERA_SETUP_KEY, "true");
+    onComplete();
+  }, [onComplete]);
+
+  const handleSkip = useCallback(async () => {
+    await AsyncStorage.setItem(CAMERA_SETUP_KEY, "skipped");
+    onSkip();
+  }, [onSkip]);
+
+  const statusColor = isReady ? "#22c55e" : elapsed >= FALLBACK_SECONDS ? "#6366f1" : "#f59e0b";
+  const statusText = isReady
+    ? "Perfect! Tap Continue"
+    : modelReady
+    ? "Keep adjusting — can't see full body yet"
+    : "Loading pose detection…";
+
+  return (
+    <SafeAreaView style={styles.container}>
+      {/* Camera preview */}
+      <CameraView
+        ref={cameraRef}
+        style={StyleSheet.absoluteFillObject}
+        facing="back"
+        onCameraReady={() => setIsCameraReady(true)}
+      />
+
+      {/* Body guide outline */}
+      <View style={styles.guideOverlay} pointerEvents="none">
+        <View style={styles.guideOutline}>
+          {/* Head */}
+          <View style={styles.guideHead} />
+          {/* Body */}
+          <View style={styles.guideBody} />
+          {/* Legs */}
+          <View style={styles.guideLegs}>
+            <View style={styles.guideLeg} />
+            <View style={styles.guideLeg} />
+          </View>
+        </View>
+      </View>
+
+      {/* Dim overlay on non-guide areas */}
+      <View style={styles.dimOverlay} pointerEvents="none" />
+
+      {/* Status indicator */}
+      <View
+        style={[styles.statusBadge, { borderColor: statusColor }]}
+        pointerEvents="none"
+      >
+        <View style={[styles.statusDot, { backgroundColor: statusColor }]} />
+        <Text style={styles.statusText}>{statusText}</Text>
+      </View>
+
+      {/* Instructions */}
+      <View style={styles.instructions} pointerEvents="none">
+        <Text style={styles.instructionTitle}>Get Your Camera Ready</Text>
+        <Text style={styles.instructionBody}>
+          Prop your phone against something stable. Step back until your full
+          body fits inside the guide.
+        </Text>
+      </View>
+
+      {/* Bottom actions */}
+      <View style={styles.bottomBar}>
+        <TouchableOpacity
+          style={[styles.continueButton, !canContinue && styles.continueButtonDisabled]}
+          onPress={handleComplete}
+          disabled={!canContinue}
+          activeOpacity={0.8}
+          accessibilityRole="button"
+          accessibilityLabel="Continue"
+          accessibilityState={{ disabled: !canContinue }}
+        >
+          <Text
+            style={[
+              styles.continueText,
+              !canContinue && styles.continueTextDisabled,
+            ]}
+          >
+            Continue
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity
+          onPress={handleSkip}
+          style={styles.skipButton}
+          accessibilityRole="button"
+          accessibilityLabel="Skip camera setup"
+        >
+          <Text style={styles.skipText}>Skip for now</Text>
+        </TouchableOpacity>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const GUIDE_WIDTH = 120;
+const GUIDE_HEIGHT = SCREEN_HEIGHT * 0.55;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#000",
+  },
+  guideOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  guideOutline: {
+    width: GUIDE_WIDTH,
+    height: GUIDE_HEIGHT,
+    alignItems: "center",
+    gap: 0,
+    marginTop: -60, // shift slightly upward to center body in frame
+  },
+  guideHead: {
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    borderWidth: 2,
+    borderColor: "rgba(255,255,255,0.7)",
+    backgroundColor: "transparent",
+  },
+  guideBody: {
+    width: 80,
+    height: GUIDE_HEIGHT * 0.38,
+    borderLeftWidth: 2,
+    borderRightWidth: 2,
+    borderColor: "rgba(255,255,255,0.7)",
+    borderBottomLeftRadius: 8,
+    borderBottomRightRadius: 8,
+    marginTop: 4,
+  },
+  guideLegs: {
+    flexDirection: "row",
+    gap: 10,
+    width: 80,
+  },
+  guideLeg: {
+    flex: 1,
+    height: GUIDE_HEIGHT * 0.4,
+    borderLeftWidth: 2,
+    borderRightWidth: 2,
+    borderBottomWidth: 2,
+    borderColor: "rgba(255,255,255,0.7)",
+    borderBottomLeftRadius: 6,
+    borderBottomRightRadius: 6,
+  },
+  dimOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0,0,0,0.25)",
+  },
+  statusBadge: {
+    position: "absolute",
+    top: 100,
+    alignSelf: "center",
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+    backgroundColor: "rgba(0,0,0,0.7)",
+    borderRadius: 20,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderWidth: 1.5,
+  },
+  statusDot: {
+    width: 8,
+    height: 8,
+    borderRadius: 4,
+  },
+  statusText: {
+    fontSize: 13,
+    fontWeight: "600",
+    color: "#ffffff",
+    maxWidth: 240,
+  },
+  instructions: {
+    position: "absolute",
+    bottom: 160,
+    left: 24,
+    right: 24,
+    backgroundColor: "rgba(0,0,0,0.65)",
+    borderRadius: 14,
+    padding: 16,
+  },
+  instructionTitle: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#ffffff",
+    marginBottom: 6,
+    textAlign: "center",
+  },
+  instructionBody: {
+    fontSize: 13,
+    color: "#ffffffcc",
+    lineHeight: 18,
+    textAlign: "center",
+  },
+  bottomBar: {
+    position: "absolute",
+    bottom: 40,
+    left: 24,
+    right: 24,
+    gap: 12,
+  },
+  continueButton: {
+    backgroundColor: "#00E5FF",
+    borderRadius: 14,
+    paddingVertical: 16,
+    alignItems: "center",
+  },
+  continueButtonDisabled: {
+    backgroundColor: "rgba(0,229,255,0.3)",
+  },
+  continueText: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: "#0a0a0f",
+  },
+  continueTextDisabled: {
+    color: "rgba(10,10,15,0.5)",
+  },
+  skipButton: {
+    alignItems: "center",
+    paddingVertical: 8,
+  },
+  skipText: {
+    fontSize: 14,
+    color: "rgba(255,255,255,0.6)",
+    fontWeight: "500",
+  },
+});


### PR DESCRIPTION
## Summary
Adds a new onboarding step after camera permission that teaches users how to position their phone before starting their first session — the #1 cause of first-session churn when pose detection fails.

## Changes
- **`src/screens/OnboardingCameraSetup.tsx`** (new) — live camera preview, body silhouette guide outline (head + torso + legs), readiness indicator, haptic SUCCESS when ready, 30s fallback, AsyncStorage persistence
- **`src/screens/Onboarding.tsx`** — `camera-setup` phase inserted after permission; skips if `onboardingCameraSetupComplete` already set
- **`src/screens/Home.tsx`** — one-time tooltip `"Tap to start — your camera guide will appear first"` shown on exercise grid, dismissed on first tap

## Acceptance criteria
- [x] New onboarding step after camera permission
- [x] Live camera preview renders
- [x] Human body silhouette guide overlay visible
- [x] Readiness indicator shows state based on pose confidence
- [x] Haptic when readiness changes to "ready"
- [x] "Continue" disabled until confidence > 0.6 for ≥ 2 seconds
- [x] 30-second fallback: Continue enables regardless
- [x] "Skip for now" always visible and functional
- [x] Shown only once (completion persisted in AsyncStorage)
- [x] One-time tooltip on first exercise card post-onboarding
- [x] TypeScript clean ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)